### PR TITLE
Teal Generators

### DIFF
--- a/lib/mix/ex_teal.install.ex
+++ b/lib/mix/ex_teal.install.ex
@@ -1,0 +1,55 @@
+defmodule Mix.Tasks.ExTeal.Gen.Install do
+  @moduledoc """
+    Generates the manifest file and basic folder structure
+  """
+
+  use Mix.Task
+  alias Mix.ExTeal.Gen.Manifest
+
+  def run(_args) do
+    manifest = Manifest.new()
+    paths = generator_paths()
+
+    prompt_for_conflicts(manifest)
+
+    manifest
+    |> create_folders()
+    |> copy_new_files(paths, manifest: manifest)
+
+    if Mix.env() != :test do
+      Mix.Shell.cmd("mix format", fn output -> IO.write(output) end)
+    end
+  end
+
+  defp create_folders(manifest) do
+    folders = folders_to_create()
+
+    Enum.each(folders, fn folder ->
+      path = manifest.web_path <> "/ex_teal/" <> folder
+      Mix.Generator.create_directory(path)
+    end)
+
+    manifest
+  end
+
+  defp copy_new_files(%Manifest{} = manifest, paths, binding) do
+    files = files_to_be_generated(manifest)
+    Mix.Phoenix.copy_from(paths, "priv/templates/ex_teal.gen.install/", binding, files)
+  end
+
+  defp prompt_for_conflicts(manifest) do
+    manifest
+    |> files_to_be_generated()
+    |> Mix.Phoenix.prompt_for_conflicts()
+  end
+
+  defp files_to_be_generated(%Manifest{} = manifest) do
+    [{:eex, "manifest.ex", manifest.file}]
+  end
+
+  defp folders_to_create do
+    ["actions", "resources"]
+  end
+
+  defp generator_paths, do: [".", :ex_teal]
+end

--- a/lib/mix/ex_teal/manifest.ex
+++ b/lib/mix/ex_teal/manifest.ex
@@ -1,0 +1,36 @@
+defmodule Mix.ExTeal.Gen.Manifest do
+  @moduledoc false
+
+  alias Mix.ExTeal.Gen.Manifest
+
+  defstruct context_app: nil,
+            base: nil,
+            web_path: nil,
+            web_namespace: nil,
+            module: nil,
+            ex_teal_context: nil,
+            humanized_name: nil,
+            file: nil
+
+  def new do
+    ctx_app = Mix.Phoenix.context_app()
+    web_path = Mix.Phoenix.web_path(ctx_app)
+    file = web_path <> "/ex_teal" <> "/manifest.ex"
+    base = Mix.Phoenix.context_base(ctx_app)
+    web_namespace = base <> "Web"
+    module = web_namespace <> ".ExTeal.Manifest"
+    ex_teal_context = web_namespace <> ".ExTeal"
+    humanized_name = Phoenix.Naming.humanize(ctx_app)
+
+    %Manifest{
+      base: base,
+      context_app: ctx_app,
+      file: file,
+      web_path: web_path,
+      web_namespace: web_namespace,
+      module: module,
+      ex_teal_context: ex_teal_context,
+      humanized_name: humanized_name
+    }
+  end
+end

--- a/lib/mix/ex_teal/resource.ex
+++ b/lib/mix/ex_teal/resource.ex
@@ -1,0 +1,252 @@
+defmodule Mix.ExTeal.Gen.Resource do
+  @moduledoc """
+    Generates an exteal resource and fields
+  """
+
+  alias Mix.ExTeal.Gen.Resource
+  alias Phoenix.Naming
+
+  defstruct model: nil,
+            file: nil,
+            title: nil,
+            web_module_alias: nil,
+            base: nil,
+            ctx_app: nil,
+            module_alias: nil,
+            types: nil,
+            fields: nil,
+            assocs: nil,
+            assocs_by_context: nil,
+            manifest_path: nil,
+            search_fields: nil
+
+  @default_search_fields [
+    :text,
+    :text_area,
+    :number
+  ]
+
+  @valid_types [
+    :array,
+    :belongs_to,
+    :boolean,
+    :color,
+    :date,
+    :date_time,
+    :has_many,
+    :has_one,
+    :ID,
+    :integer,
+    :many_to_many,
+    :many_to_many_belongs_to,
+    :multi_select,
+    :number,
+    :password,
+    :place,
+    :rich_text,
+    :select,
+    :text,
+    :text_area,
+    :toggle
+  ]
+  @valid_assoc_types [
+    :belongs_to,
+    :has_many,
+    :has_one,
+    :many_to_many,
+    :many_to_many_belongs_to
+  ]
+
+  def valid_types, do: @valid_types
+
+  def valid?(resource) do
+    resource =~ ~r/^[A-Z]\w*(\.[A-Z]\w*)*$/
+  end
+
+  def new(resource_name, cli_attrs) do
+    ctx_app = Mix.Phoenix.context_app()
+    inflections = Mix.Phoenix.inflect(resource_name)
+
+    file = resource_file_path(ctx_app, inflections[:singular])
+    web_module_alias = web_module_alias(inflections)
+    module = inflections[:module]
+    {assocs, attrs} = partition_attrs_and_assocs(attrs(cli_attrs))
+    assocs_by_context = assocs_by_context(assocs)
+    search_fields = default_search_fields(attrs)
+
+    types = attrs |> types()
+
+    all_teal_fields = fields(format_types(types) ++ format_assoc_types(assocs))
+
+    %Resource{
+      ctx_app: ctx_app,
+      base: inflections[:base],
+      model: inflections[:alias],
+      file: file,
+      title: inflections[:human],
+      module_alias: module,
+      web_module_alias: web_module_alias,
+      types: types,
+      fields: all_teal_fields,
+      assocs: assocs,
+      assocs_by_context: assocs_by_context,
+      manifest_path: Mix.Phoenix.web_path(ctx_app) <> "/ex_teal/manifest.ex",
+      search_fields: search_fields
+    }
+  end
+
+  defp default_search_fields(attrs) do
+    attrs
+    |> Enum.group_by(fn {_k, v} -> v end, fn {k, _v} ->
+      k
+    end)
+    |> Map.take(@default_search_fields)
+    |> Map.values()
+    |> List.flatten()
+  end
+
+  defp assocs_by_context([]), do: nil
+
+  defp assocs_by_context(assocs) do
+    case assocs do
+      {_flag, _key, _type} ->
+        assocs
+        |> Enum.group_by(fn {_f, _k, _t} -> "" end, fn {_f, module, _t} -> module end)
+
+      _ ->
+        assocs
+        |> Enum.group_by(fn {_k, _m, _t, context} -> context end, fn {_k, module, _t, _c} ->
+          module
+        end)
+    end
+  end
+
+  defp fields(types), do: types |> Enum.sort() |> Enum.join(", ")
+
+  defp format_types(types) do
+    types
+    |> Enum.map(fn {_k, v} -> v end)
+  end
+
+  defp format_assoc_types(assocs) do
+    Enum.map(assocs, fn
+      {_k, _v, type, _c} -> type
+      {_k, _v, type} -> type
+    end)
+  end
+
+  defp partition_attrs_and_assocs(attrs) do
+    {assocs, attrs} =
+      Enum.split_with(attrs, fn
+        {:assoc, key, assoc_type} ->
+          if Enum.member?(@valid_assoc_types, assoc_type) do
+            true
+          else
+            Mix.raise("""
+            ExTeal generator expects the assoc to be given to assoc:#{key}.
+            For example:
+                mix ex_teal.gen.resource Comment comments assoc:post:belongs_to
+            """)
+          end
+
+        {:assoc, key, _, _, assoc_type} ->
+          if Enum.member?(@valid_assoc_types, assoc_type) do
+            true
+          else
+            Mix.raise("""
+            ExTeal generator expects the assoc to be given to assoc:#{key}.
+            For example:
+                mix ex_teal.gen.resource Comment comments assoc:post:belongs_to:context:content
+            """)
+          end
+
+        _ ->
+          false
+      end)
+
+    assocs =
+      Enum.map(assocs, fn
+        {_flag, key, :context, type, context} ->
+          {key, Phoenix.Naming.camelize(Atom.to_string(key)),
+           Phoenix.Naming.camelize(Atom.to_string(context)),
+           Phoenix.Naming.camelize(Atom.to_string(type))}
+
+        {_flag, key, type} ->
+          {key, Phoenix.Naming.camelize(Atom.to_string(key)),
+           Phoenix.Naming.camelize(Atom.to_string(type))}
+      end)
+
+    {assocs, attrs}
+  end
+
+  @doc """
+  Parses the attrs as received by generators.
+  """
+  def attrs(attrs) do
+    ["id:ID" | attrs]
+    |> Enum.map(fn attr ->
+      attr
+      |> String.split(":", parts: 5)
+      |> list_to_attr()
+      |> validate_attr!()
+    end)
+  end
+
+  defp list_to_attr([key]), do: {String.to_atom(key), :text}
+  defp list_to_attr([key, value]), do: {String.to_atom(key), String.to_atom(value)}
+
+  defp list_to_attr([assoc_flag, assoc, type]),
+    do: {String.to_atom(assoc_flag), String.to_atom(assoc), String.to_atom(type)}
+
+  defp list_to_attr([assoc_flag, assoc, type, context_flag, context]),
+    do:
+      {String.to_atom(assoc_flag), String.to_atom(assoc), String.to_atom(context_flag),
+       String.to_atom(context), String.to_atom(type)}
+
+  defp types(attrs) do
+    Enum.into(attrs, %{}, fn
+      {key, val} ->
+        {key, Naming.camelize(Atom.to_string(val))}
+
+      {assoc, context, type} ->
+        {assoc, context, type}
+    end)
+  end
+
+  defp web_module_alias(
+         alias: aliased,
+         human: _,
+         base: _,
+         web_module: web_module,
+         module: _,
+         scoped: _,
+         singular: _,
+         path: _
+       ) do
+    web_module <> ".ExTeal." <> aliased <> "Resource"
+  end
+
+  defp resource_file_path(ctx_app, singular) do
+    ctx_app
+    |> Mix.Phoenix.web_path()
+    |> Kernel.<>("/ex_teal/resources/#{singular}_resource.ex")
+  end
+
+  defp validate_attr!({_name, type} = attr) when type in @valid_types, do: attr
+  defp validate_attr!({_name, {type, _}} = attr) when type in @valid_types, do: attr
+
+  defp validate_attr!({_assoc_flag, _assoc, type} = attr)
+       when type in @valid_assoc_types,
+       do: attr
+
+  defp validate_attr!({_assoc_flag, _assoc, _context_flag, _context, type} = attr)
+       when type in @valid_assoc_types,
+       do: attr
+
+  defp validate_attr!({_, type}) do
+    Mix.raise(
+      "Unknown type `#{inspect(type)}` given to generator. " <>
+        "The supported types are: #{@valid_types |> Enum.sort() |> Enum.join(", ")}"
+    )
+  end
+end

--- a/lib/mix/tasks/ex_teal.gen.resource.ex
+++ b/lib/mix/tasks/ex_teal.gen.resource.ex
@@ -1,0 +1,224 @@
+defmodule Mix.Tasks.ExTeal.Gen.Resource do
+  use Mix.Task
+  alias Mix.ExTeal.Gen.Resource
+
+  @moduledoc """
+  Generates an ex_teal resource
+  """
+
+  @switches []
+
+  def run(args) do
+    resource = build(args)
+
+    if File.exists?(resource.manifest_path) do
+      paths = generator_paths()
+
+      prompt_for_conflicts(resource)
+
+      resource
+      |> copy_new_files(paths, resource: resource)
+      |> maybe_inject_into_manifest()
+
+      if Mix.env() != :test do
+        Mix.Shell.cmd("mix format", fn output -> IO.write(output) end)
+      end
+    else
+      raise_with_help(
+        "Expected to find a manifest.ex file, please run 'mix ex_teal.gen.install before generating a resource."
+      )
+    end
+  end
+
+  @doc false
+  def build(args) do
+    {_, parsed, _} = OptionParser.parse(args, switches: @switches)
+    [resource_name | attrs] = validate_args!(parsed)
+
+    Resource.new(resource_name, attrs)
+  end
+
+  defp maybe_inject_into_manifest(
+         %Resource{ctx_app: ctx_app, web_module_alias: module} = resource
+       ) do
+    web_prefix = Mix.Phoenix.web_path(ctx_app)
+    file_path = Path.join(web_prefix, "ex_teal/manifest.ex")
+    file = File.read!(file_path)
+    resource_module = String.split(module, ".") |> List.last()
+
+    if String.contains?(file, resource_module) do
+      :ok
+    else
+      do_inject_resource(file, file_path, resource_module, resource)
+    end
+
+    resource
+  end
+
+  defp do_inject_resource(file, file_path, resource_module, resource) do
+    [new_file, alias_inject] = inject_alias_into_manifest(file, resource, resource_module)
+    [new_file, resource_inject] = inject_resource_into_manifest(new_file, resource_module)
+
+    if file != new_file do
+      File.write!(file_path, new_file)
+    else
+      Mix.shell().info("""
+        Add your #{inspect(resource_module)} alias to #{file_path}:
+          defmodule #{inspect(resource.web_module_alias)}.Manifest do
+            #{alias_inject}
+
+            #{resource_inject}
+            ...
+          end
+      """)
+    end
+  end
+
+  def inject_alias_into_manifest(file, resource, resource_module) do
+    [regex, alias_inject] =
+      cond do
+        empty_alias_line?(file, resource) ->
+          replace_regex = ~r/alias #{resource.base}Web.ExTeal.\{\}/
+          alias_inject = "alias #{resource.base}Web.ExTeal.\{#{resource_module}\}"
+          [replace_regex, alias_inject]
+
+        has_multiline_alias?(file, resource) ->
+          regex_for_parse = ~r/alias #{resource.base}Web.ExTeal.\{[^}]*/
+          alias_inject = run_regex_and_parse(file, resource_module, regex_for_parse)
+
+          replace_regex = ~r/alias #{resource.base}Web.ExTeal.\{\n[[A-Za-z,\s\n]*/
+          [replace_regex, alias_inject]
+
+        true ->
+          alias_inject = singleline_alias_for_inject(resource, resource_module, file)
+          regex = ~r/alias #{resource.base}Web.ExTeal.\{[A-Za-z,\s\n]*/
+          [regex, alias_inject]
+      end
+
+    new_file = Regex.replace(regex, file, alias_inject)
+    [new_file, alias_inject]
+  end
+
+  def inject_resource_into_manifest(file, resource_module) do
+    [regex, resource_inject] =
+      cond do
+        empty_resource_line?(file) ->
+          replace_regex = ~r/def resources, do: \[\]/
+          resource_inject = "def resources, do: [#{resource_module}]"
+          [replace_regex, resource_inject]
+
+        has_multiline_resource_block?(file) ->
+          resource_inject = multiline_resource_inject(resource_module, file)
+          replace_regex = ~r/def resources,\n    do: \[[A-Za-z,\s\n]*/s
+          [replace_regex, resource_inject]
+
+        true ->
+          resource_inject = singleline_resource_inject(resource_module, file)
+
+          regex = ~r/def resources, do: \[[^\]]*/
+          [regex, resource_inject]
+      end
+
+    new_file = Regex.replace(regex, file, resource_inject)
+    [new_file, resource_inject]
+  end
+
+  def has_multiline_alias?(file, resource),
+    do: String.match?(file, ~r/alias #{resource.base}Web.ExTeal.\{\n/)
+
+  def has_multiline_resource_block?(file),
+    do: String.match?(file, ~r/def resources,\n    do: \[[^\]]*/)
+
+  def empty_resource_line?(file),
+    do: String.match?(file, ~r/def resources, do: \[\]/)
+
+  def empty_alias_line?(file, resource),
+    do: String.match?(file, ~r/alias #{resource.base}Web.ExTeal.\{\}/)
+
+  def singleline_alias_for_inject(resource, resource_module, file) do
+    inject = run_regex_and_parse(file, resource_module, ~r/(?<=\{).+?(?=\})/)
+
+    "alias #{resource.base}Web.ExTeal.\{#{inject}"
+  end
+
+  def singleline_resource_inject(resource_module, file) do
+    regex = ~r/def resources, do: \[[^\]]*/
+    inject = run_regex_and_parse(file, resource_module, regex)
+    inject
+  end
+
+  def multiline_resource_inject(resource_module, file) do
+    inject = run_regex_and_parse(file, resource_module, ~r/(?<=\[).+?(?=\])/s)
+
+    "def resources,    do: \[#{inject}"
+  end
+
+  defp run_regex_and_parse(file, resource_module, regex) do
+    regex
+    |> Regex.run(file)
+    |> parse_inject(resource_module)
+  end
+
+  defp parse_inject(["Endpoint.url()"], resource_module), do: resource_module
+
+  defp parse_inject([inject_line], resource_module) do
+    inject_line
+    |> String.replace("\n", "")
+    |> String.split(",")
+    |> Enum.concat([resource_module])
+    |> Enum.join(",")
+  end
+
+  defp prompt_for_conflicts(resource) do
+    resource
+    |> files_to_be_generated()
+    |> Mix.Phoenix.prompt_for_conflicts()
+  end
+
+  @doc false
+  defp validate_args!([resource | _] = args) do
+    if Resource.valid?(resource) do
+      args
+    else
+      raise_with_help(
+        "Expected the resource argument, #{inspect(resource)}, to be a valid module name"
+      )
+    end
+  end
+
+  defp validate_args!(_) do
+    raise_with_help("Invalid arguments")
+  end
+
+  defp copy_new_files(%Resource{} = resource, paths, binding) do
+    files = files_to_be_generated(resource)
+    Mix.Phoenix.copy_from(paths, "priv/templates/ex_teal.gen/", binding, files)
+
+    resource
+  end
+
+  defp files_to_be_generated(%Resource{} = resource) do
+    [{:eex, "resource.ex", resource.file}]
+  end
+
+  defp generator_paths, do: [".", :ex_teal]
+
+  @doc false
+  @spec raise_with_help(String.t()) :: no_return()
+  def raise_with_help(msg) do
+    Mix.raise("""
+    #{msg}
+
+      mix ex_teal.gen.resource expects the module name in camelCase format,
+      for proper aliasing include contexts,
+
+      for example:
+
+        mix ex_teal.gen.resource User
+
+      with a context:
+
+        mix ex_teal.gen.resource Accounts.User
+    """)
+  end
+end

--- a/priv/templates/ex_teal.gen.install/manifest.ex
+++ b/priv/templates/ex_teal.gen.install/manifest.ex
@@ -1,0 +1,17 @@
+defmodule <%= manifest.module %> do
+  @moduledoc """
+  Configure ExTeal
+  """
+  use ExTeal.Manifest
+
+  alias <%= manifest.ex_teal_context %>.{}
+
+  def resources, do: []
+
+  def plugins,
+    do: []
+
+  def dashboards, do: []
+
+  def application_name, do: <%= inspect manifest.humanized_name %>
+end

--- a/priv/templates/ex_teal.gen/resource.ex
+++ b/priv/templates/ex_teal.gen/resource.ex
@@ -1,0 +1,36 @@
+defmodule <%= resource.web_module_alias %> do
+  @moduledoc """
+    ExTeal Resource
+  """
+  use ExTeal.Resource
+  alias <%= resource.module_alias %>
+  alias ExTeal.Fields.{<%= resource.fields %>}
+<%= if resource.assocs_by_context do %>
+<%= for {k, v} <- resource.assocs_by_context do %>
+  alias <%=resource.base%>.<%=k%>.{<%=v |> Enum.sort() |> Enum.join(", ")%>}
+<% end %>
+<% end %>
+
+  @impl true
+  def model, do: <%= resource.model %>
+
+  @impl true
+  def with, do: []
+
+  @impl true
+  def title, do: "<%= resource.title %>"
+
+  @impl true
+  def actions(_), do: []
+
+  @impl true
+  def search, do: [<%= for k <- resource.search_fields do %><%= inspect k %>, <% end %>]
+
+  @impl true
+  def fields, do: [
+  <%= for {k, v} <- resource.types do %> <%= v |> to_string() |> String.split(".") |> List.last %>.make(<%= inspect k %>),
+  <% end %><%= for {k, camel_key, type, _context} <- resource.assocs do %> <%= type %>.make(<%= inspect k %>, <%= camel_key %>),
+  <% end %>]
+
+end
+

--- a/test/mix/tasks/ex_teal.gen.install_test.exs
+++ b/test/mix/tasks/ex_teal.gen.install_test.exs
@@ -1,0 +1,24 @@
+Code.require_file("../../mix_helper.exs", __DIR__)
+
+defmodule Mix.Tasks.ExTeal.Gen.InstallTest do
+  use ExUnit.Case
+
+  import MixHelper
+  alias Mix.Tasks.ExTeal.Gen
+
+  setup do
+    Mix.Task.clear()
+    :ok
+  end
+
+  test "generates manifest file", config do
+    in_tmp_project(config.test, fn ->
+      Gen.Install.run("")
+
+      assert_file("lib/ex_teal_web/ex_teal/manifest.ex", fn file ->
+        assert file =~ "defmodule ExTealWeb.ExTeal.Manifest"
+        assert file =~ "def application_name, do:"
+      end)
+    end)
+  end
+end

--- a/test/mix/tasks/ex_teal.gen.resource_test.exs
+++ b/test/mix/tasks/ex_teal.gen.resource_test.exs
@@ -1,0 +1,157 @@
+Code.require_file("../../mix_helper.exs", __DIR__)
+
+defmodule Mix.Tasks.ExTeal.Gen.ResourceTest do
+  use ExUnit.Case
+
+  import MixHelper
+  alias Mix.Tasks.ExTeal.Gen
+
+  setup do
+    Mix.Task.clear()
+    :ok
+  end
+
+  test "generates resource file", config do
+    in_tmp_project(config.test, fn ->
+      Gen.Install.run("")
+      Gen.Resource.run(["Accounts.User", "name:text_area", "admin:boolean"])
+
+      assert_file("lib/ex_teal_web/ex_teal/resources/user_resource.ex", fn file ->
+        assert file =~ "defmodule ExTealWeb.ExTeal.UserResource"
+        assert file =~ "alias ExTeal.Fields.{Boolean, ID, TextArea}"
+        assert file =~ "TextArea.make(:name)"
+        assert file =~ "Boolean.make(:admin)"
+      end)
+
+      assert_file("lib/ex_teal_web/ex_teal/manifest.ex", fn file ->
+        assert file =~ "alias ExTealWeb.ExTeal.{UserResource"
+        assert file =~ "def resources, do: [UserResource"
+      end)
+    end)
+  end
+
+  test "if manifest not found, prompts user to run install command", config do
+    in_tmp_project(config.test, fn ->
+      assert_raise Mix.Error,
+                   ~r/Expected to find a manifest.ex file, please run 'mix ex_teal.gen.install before generating a resource./,
+                   fn ->
+                     Gen.Resource.run(["Accounts.User", "name:text_area", "admin:boolean"])
+                   end
+    end)
+  end
+
+  test "generating more resources does not overwrite aliases in manifest", config do
+    in_tmp_project(config.test, fn ->
+      Gen.Install.run("")
+      Gen.Resource.run(["Accounts.User", "name:text_area", "admin:boolean"])
+      Gen.Resource.run(["Accounts.Address", "street:text_area", "zip:text_area"])
+      Gen.Resource.run(["Content.Article", "title:text_area"])
+
+      assert_file("lib/ex_teal_web/ex_teal/manifest.ex", fn file ->
+        assert file =~
+                 "alias ExTealWeb.ExTeal.{UserResource,AddressResource,ArticleResource}"
+
+        assert file =~
+                 "def resources, do: [UserResource,AddressResource,ArticleResource]"
+      end)
+    end)
+  end
+
+  test "generates resource without context", config do
+    in_tmp_project(config.test, fn ->
+      Gen.Install.run("")
+      Gen.Resource.run(["User", "name:text_area", "admin:boolean"])
+
+      assert_file("lib/ex_teal_web/ex_teal/resources/user_resource.ex", fn file ->
+        assert file =~ "defmodule ExTealWeb.ExTeal.UserResource"
+        assert file =~ "alias ExTeal.Fields.{Boolean, ID, TextArea}"
+      end)
+    end)
+  end
+
+  test "generates field and aliases for belongs to assoc with context", config do
+    in_tmp_project(config.test, fn ->
+      Gen.Install.run("")
+      Gen.Resource.run(["User", "assoc:vc_fund:belongs_to:context:profiles", "admin:boolean"])
+
+      assert_file("lib/ex_teal_web/ex_teal/resources/user_resource.ex", fn file ->
+        assert file =~ "defmodule ExTealWeb.ExTeal.UserResource"
+        assert file =~ "BelongsTo.make(:vc_fund, VcFund)"
+        assert file =~ "alias ExTeal.Fields.{BelongsTo"
+        assert file =~ "alias ExTeal.Profiles.{VcFund"
+      end)
+    end)
+  end
+
+  test "generates aliases for multiple assocs", config do
+    in_tmp_project(config.test, fn ->
+      Gen.Install.run("")
+
+      Gen.Resource.run([
+        "User",
+        "assoc:vc_fund:belongs_to:context:profiles",
+        "assoc:portfolio_company:has_many:context:profiles"
+      ])
+
+      assert_file("lib/ex_teal_web/ex_teal/resources/user_resource.ex", fn file ->
+        assert file =~ "defmodule ExTealWeb.ExTeal.UserResource"
+        assert file =~ "BelongsTo.make(:vc_fund, VcFund)"
+        assert file =~ "alias ExTeal.Fields.{BelongsTo"
+        assert file =~ "alias ExTeal.Profiles.{PortfolioCompany, VcFund"
+      end)
+    end)
+  end
+
+  test "generates search block w/ eligible default fields", config do
+    in_tmp_project(config.test, fn ->
+      Gen.Install.run("")
+
+      Gen.Resource.run([
+        "Article",
+        "body:text_area",
+        "title:text",
+        "order:number",
+        "published:boolean"
+      ])
+
+      assert_file("lib/ex_teal_web/ex_teal/resources/article_resource.ex", fn file ->
+        assert file =~ "def search, do: [:order, :title, :body"
+      end)
+    end)
+  end
+
+  describe "invalid mix arguments" do
+    test "does not generate resource for bad schema arg", config do
+      in_tmp_project(config.test, fn ->
+        assert_raise Mix.Error,
+                     ~r/Expected the resource argument, "user", to be a valid module name/,
+                     fn ->
+                       Gen.Install.run("")
+                       Gen.Resource.run(["user", "name:text_area", "admin:boolean"])
+                     end
+      end)
+    end
+
+    test "does not generate resource for context arg", config do
+      in_tmp_project(config.test, fn ->
+        assert_raise Mix.Error,
+                     ~r/Expected the resource argument, "accounts.User", to be a valid module name/,
+                     fn ->
+                       Gen.Install.run("")
+                       Gen.Resource.run(["accounts.User", "name:text_area", "admin:boolean"])
+                     end
+      end)
+    end
+
+    test "error if invalid field type", config do
+      in_tmp_project(config.test, fn ->
+        assert_raise Mix.Error,
+                     ~r/Unknown type `:bad_field` given to generator. The supported types are: ID, array, belongs_to, boolean, color, date, date_time, has_many, has_one, integer, many_to_many, many_to_many_belongs_to, multi_select, number, password, place, rich_text, select, text, text_area, toggle/,
+                     fn ->
+                       Gen.Install.run("")
+                       Gen.Resource.run(["Accounts.User", "name:bad_field", "admin:boolean"])
+                     end
+      end)
+    end
+  end
+end

--- a/test/mix_helper.exs
+++ b/test/mix_helper.exs
@@ -1,0 +1,129 @@
+Mix.shell(Mix.Shell.Process)
+
+# mock live reloading for testing the generated application
+
+defmodule Phoenix.LiveReloader do
+  def init(opts), do: opts
+  def call(conn, _), do: conn
+end
+
+defmodule MixHelper do
+  import ExUnit.Assertions
+  import ExUnit.CaptureIO
+
+  def tmp_path do
+    Path.expand("../../tmp", __DIR__)
+  end
+
+  def random_string(len) do
+    len |> :crypto.strong_rand_bytes() |> Base.encode64() |> binary_part(0, len)
+  end
+
+  def in_tmp(which, function) do
+    path = Path.join([tmp_path(), random_string(10), to_string(which)])
+
+    try do
+      File.rm_rf!(path)
+      File.mkdir_p!(path)
+      File.cd!(path, function)
+    after
+      File.rm_rf!(path)
+    end
+  end
+
+  def in_tmp_project(which, function) do
+    conf_before = Application.get_env(:phoenix, :generators) || []
+    path = Path.join([tmp_path(), random_string(10), to_string(which)])
+
+    try do
+      apps_path = Path.join(path, "apps")
+      config_path = Path.join(path, "config")
+      File.rm_rf!(path)
+      File.mkdir_p!(path)
+      File.mkdir_p!(apps_path)
+      File.mkdir_p!(config_path)
+      File.touch!(Path.join(path, "mix.exs"))
+
+      for file <- ~w(config.exs dev.exs test.exs prod.exs) do
+        File.write!(Path.join(config_path, file), "use Mix.Config\n")
+      end
+
+      File.cd!(apps_path, function)
+    after
+      Application.put_env(:phoenix, :generators, conf_before)
+      File.rm_rf!(path)
+    end
+  end
+
+  def in_project(app, path, fun) do
+    %{name: name, file: file} = Mix.Project.pop()
+
+    try do
+      capture_io(:stderr, fn ->
+        Mix.Project.in_project(app, path, [], fun)
+      end)
+    after
+      Mix.Project.push(name, file)
+    end
+  end
+
+  def assert_file(file) do
+    assert File.regular?(file), "Expected #{file} to exist, but it does not"
+  end
+
+  def refute_file(file) do
+    refute File.regular?(file), "Expected #{file} not to exist, but it does"
+  end
+
+  def assert_file(file, match) do
+    cond do
+      is_list(match) ->
+        assert_file(file, &Enum.each(match, fn m -> assert &1 =~ m end))
+
+      is_binary(match) or Regex.regex?(match) ->
+        assert_file(file, &assert(&1 =~ match))
+
+      is_function(match, 1) ->
+        assert_file(file)
+        match.(File.read!(file))
+
+      true ->
+        raise inspect({file, match})
+    end
+  end
+
+  def with_generator_env(new_env, fun) do
+    Application.put_env(:phoenix, :generators, new_env)
+
+    try do
+      fun.()
+    after
+      Application.delete_env(:phoenix, :generators)
+    end
+  end
+
+  def umbrella_mixfile_contents do
+    """
+    defmodule Umbrella.MixProject do
+      use Mix.Project
+      def project do
+        [
+          apps_path: "apps",
+          deps: deps()
+        ]
+      end
+      defp deps do
+        []
+      end
+    end
+    """
+  end
+
+  def flush do
+    receive do
+      _ -> flush()
+    after
+      0 -> :ok
+    end
+  end
+end


### PR DESCRIPTION
to do:
update README.md, I just really really wanted to get this transferred back into the teal repo and up in an MR today.

format of install and gen resource commands:

```elixir
mix ex_teal.install

#generate resource w/ no context
mix ex_teal.gen.resource User name:text_area address:text admin:boolean

#generate resource w/ context
mix ex_teal.gen.resource User name:text_area address:text admin:boolean

#generate resource w/ basic association, association does not belong to a context
mix ex_teal.gen User assoc:profile:belongs_to

#generate resource w/ association that needs to be aliased in a context
mix ex_teal.gen.resource Testers assoc:vc_fund:belongs_to:context:profiles
```

note:
I did leave the injects in place to see if we can keep them injecting by the correct contexts -- if it turns out to be brittle I'm happy to pull it out and just replace that with injecting them on individual lines, instead of grouped. 