### PR TITLE
fix: HasOne Index View

### DIFF
--- a/assets/src/components/Index/HasOne.vue
+++ b/assets/src/components/Index/HasOne.vue
@@ -5,7 +5,7 @@
         :to="{
           name: 'detail',
           params: {
-            resourceName: field.options.has_one_relationship,
+            resourceName: field.options.uri,
             resourceId: field.options.has_one_id
           }
         }"

--- a/lib/ex_teal/fields/has_one.ex
+++ b/lib/ex_teal/fields/has_one.ex
@@ -49,9 +49,12 @@ defmodule ExTeal.Fields.HasOne do
     rel = model.__struct__.__schema__(:association, field.field)
 
     with {:ok, resource} <- ExTeal.resource_for_model(rel.queryable) do
+      related = Map.get(model, field.field)
+
       opts =
         Map.merge(field.options, %{
           has_one_relationship: field.field,
+          has_one_id: Map.get(related, :id),
           listable: true
         })
 

--- a/test/ex_teal/fields/has_one_test.exs
+++ b/test/ex_teal/fields/has_one_test.exs
@@ -1,0 +1,17 @@
+defmodule ExTeal.Fields.HasOneTest do
+  use TestExTeal.ConnCase
+  alias ExTeal.Fields.HasOne
+
+  describe "apply_options_for/3" do
+    @tag manifest: TestExTeal.DefaultManifest
+    test "adds the related type and id to the options" do
+      [_, field] = TestExTeal.SinglePostUserResource.fields()
+      post = insert(:post)
+      user = insert(:single_post_user, post: post)
+
+      field = HasOne.apply_options_for(field, user, :index)
+      assert field.options.has_one_relationship == :post
+      assert field.options.has_one_id == post.id
+    end
+  end
+end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -3,7 +3,7 @@ defmodule TestExTeal.Factory do
 
   use ExMachina.Ecto, repo: TestExTeal.Repo
 
-  alias TestExTeal.{Order, Post, PreferredTag, Tag, User}
+  alias TestExTeal.{Order, Post, PreferredTag, SinglePostUser, Tag, User}
 
   def user_factory do
     %User{
@@ -18,6 +18,13 @@ defmodule TestExTeal.Factory do
       body: "Bacon Ipsum Lorem",
       published: true,
       user: build(:user)
+    }
+  end
+
+  def single_post_user_factory do
+    %SinglePostUser{
+      email: "foo@gmail.com",
+      post: build(:post)
     }
   end
 

--- a/test/support/manifests.exs
+++ b/test/support/manifests.exs
@@ -5,7 +5,8 @@ defmodule TestExTeal.DefaultManifest do
     do: [
       TestExTeal.UserResource,
       TestExTeal.PostResource,
-      TestExTeal.TagResource
+      TestExTeal.TagResource,
+      TestExTeal.SinglePostUserResource
     ]
 
   def dashboards,

--- a/test/support/resources.exs
+++ b/test/support/resources.exs
@@ -64,3 +64,17 @@ defmodule TestExTeal.TagResource do
       ManyToMany.make(:posts, TestExTeal.Post)
     ]
 end
+
+defmodule TestExTeal.SinglePostUserResource do
+  use ExTeal.Resource
+
+  alias ExTeal.Fields.{HasOne, ID}
+
+  def model, do: TestExTeal.SinglePostUser
+
+  def fields,
+    do: [
+      ID.make(:id),
+      HasOne.make(:post, TestExTeal.Post)
+    ]
+end

--- a/test/support/schema.exs
+++ b/test/support/schema.exs
@@ -122,3 +122,15 @@ defmodule TestExTeal.Order do
     timestamps()
   end
 end
+
+defmodule TestExTeal.SinglePostUser do
+  use Ecto.Schema
+
+  schema "users" do
+    field(:email, :string)
+
+    has_one(:post, TestExTeal.Post, foreign_key: :user_id)
+
+    timestamps()
+  end
+end


### PR DESCRIPTION
The `HasOne` field depends on a `has_one_id` and `has_one_relationship`
as field options to build the Index link and the Detail View Table.

The `has_one_id` field was not being returned in the options, making the
link return an invalid url.

This commit also fixes a bug with the `HasOne` Index field that also
used the `has_one_relationship` and not the relationships' `uri`.

In short, this PR turns the link on an `Index` field where a User
`has_one` Post from `/resources/post/NAN` to `/resources/posts/1`.

Closes #6