### PR TITLE
Fix Invalid 204 Responses

### DIFF
--- a/lib/ex_teal/api/many_to_many.ex
+++ b/lib/ex_teal/api/many_to_many.ex
@@ -124,7 +124,7 @@ defmodule ExTeal.Api.ManyToMany do
           |> resource.repo().update()
 
         {:ok, body} = Jason.encode(%{detached: true})
-        Serializer.as_json(conn, body, 204)
+        Serializer.as_json(conn, body, 200)
       else
         ErrorSerializer.handle_error(conn, {:error, :not_found})
       end
@@ -221,13 +221,15 @@ defmodule ExTeal.Api.ManyToMany do
         end)
         |> Enum.into([])
 
-      {_updated, nil} =
-        pivot
-        |> pivot_query(schema, related)
-        |> resource.repo().update_all(set: updates)
+      if !Enum.empty?(updates) do
+        {_updated, nil} =
+          pivot
+          |> pivot_query(schema, related)
+          |> resource.repo().update_all(set: updates)
+      end
 
       {:ok, body} = Jason.encode(%{updated: true})
-      Serializer.as_json(conn, body, 204)
+      Serializer.as_json(conn, body, 200)
     else
       nil ->
         ErrorSerializer.handle_error(conn, {:error, :not_found})
@@ -264,7 +266,7 @@ defmodule ExTeal.Api.ManyToMany do
       case resource.repo().transaction(multi) do
         {:ok, _updated} ->
           {:ok, body} = Jason.encode(%{updated: true})
-          Serializer.as_json(conn, body, 204)
+          Serializer.as_json(conn, body, 200)
 
         {:error, _, _, _} ->
           ErrorSerializer.handle_error(conn, {:error, :not_found})

--- a/test/ex_teal/api/many_to_many_test.exs
+++ b/test/ex_teal/api/many_to_many_test.exs
@@ -180,7 +180,7 @@ defmodule ExTeal.Api.ManyToManyTest do
     end
 
     @tag manifest: DefaultManifest
-    test "returns a 204 after detaching the field" do
+    test "returns a 200 after detaching the field" do
       t = insert(:tag)
       p = insert(:post, tags: [t])
 
@@ -191,7 +191,7 @@ defmodule ExTeal.Api.ManyToManyTest do
 
       resp = ManyToMany.detach(conn, "posts", "#{p.id}", "tags")
 
-      assert resp.status == 204
+      assert resp.status == 200
 
       post = Post |> Repo.get(p.id) |> Repo.preload(:tags)
       assert post.tags == []
@@ -383,7 +383,7 @@ defmodule ExTeal.Api.ManyToManyTest do
         })
 
       resp = ManyToMany.update_pivot(conn, "users", "#{u.id}", "preferred_tags", "#{t.id}")
-      assert resp.status == 204
+      assert resp.status == 200
 
       result = Repo.get(PreferredTag, pt.id)
       assert result.order == 1
@@ -434,7 +434,7 @@ defmodule ExTeal.Api.ManyToManyTest do
         })
 
       resp = ManyToMany.reorder(conn, "users", "#{u.id}", "preferred_tags")
-      assert resp.status == 204
+      assert resp.status == 200
 
       result = Repo.get(PreferredTag, pt1.id)
       assert result.order == 5


### PR DESCRIPTION
Apparently 204 status codes require that the body of the response is in
fact empty.  This commit fixes a deep, dark erlang cowboy error by
cleaning up the 204s and setting them to 200s