### PR TITLE
Fix an empty `HasOne` field.

### DIFF
--- a/lib/ex_teal/fields/has_one.ex
+++ b/lib/ex_teal/fields/has_one.ex
@@ -49,16 +49,19 @@ defmodule ExTeal.Fields.HasOne do
     rel = model.__struct__.__schema__(:association, field.field)
 
     with {:ok, resource} <- ExTeal.resource_for_model(rel.queryable) do
-      related = Map.get(model, field.field)
+      related = Map.get(model, field.field, %{})
 
       opts =
         Map.merge(field.options, %{
           has_one_relationship: field.field,
-          has_one_id: Map.get(related, :id),
+          has_one_id: id_for_related(related),
           listable: true
         })
 
       Map.put(field, :options, Map.merge(Resource.to_json(resource), opts))
     end
   end
+
+  defp id_for_related(nil), do: nil
+  defp id_for_related(rel), do: Map.get(rel, :id)
 end

--- a/test/ex_teal/fields/has_one_test.exs
+++ b/test/ex_teal/fields/has_one_test.exs
@@ -13,5 +13,14 @@ defmodule ExTeal.Fields.HasOneTest do
       assert field.options.has_one_relationship == :post
       assert field.options.has_one_id == post.id
     end
+
+    @tag manifest: TestExTeal.DefaultManifest
+    test "returns with an empty relationship" do
+      [_, field] = TestExTeal.SinglePostUserResource.fields()
+      user = insert(:single_post_user, post: nil)
+      field = HasOne.apply_options_for(field, user, :index)
+      assert field.options.has_one_relationship == :post
+      assert field.options.has_one_id == nil
+    end
   end
 end


### PR DESCRIPTION
If a `has_one` field on an ecto schema has no related schema, there is no identifier.