### PR TITLE
Boolean Group Field

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -20,6 +20,7 @@
     "popper.js": "^1.14.4",
     "portal-vue": "^1.3.0",
     "trix": "^0.12.1",
+    "v-tooltip": "^2.0.3",
     "vue": "^2.6.10",
     "vue-async-computed": "^3.4.1",
     "vue-chartjs": "^3.5.0",

--- a/assets/src/ExTeal.js
+++ b/assets/src/ExTeal.js
@@ -2,11 +2,13 @@ import Vue from 'vue';
 import App from './App.vue';
 import PortalVue from 'portal-vue';
 import Toasted from 'vue-toasted';
+import VTooltip from 'v-tooltip';
+
 import './util/chart-adapter';
 
 import router from '@/router';
 import axios from '@/util/axios';
-
+Vue.use(VTooltip);
 Vue.use(Toasted, {
   theme: 'nova',
   position: 'bottom-right',

--- a/assets/src/assets/css/main.css
+++ b/assets/src/assets/css/main.css
@@ -542,6 +542,34 @@ textarea, select, input, button, .checkbox { outline: none; z-index: 10}
 .fade-leave-to {
   opacity: 0;
 }
+/* Tooltip
+---------------------------------------------------------------------------- */
+.tooltip {
+  @apply bg-white px-3 py-2 rounded border border-50 shadow text-sm leading-normal;
+}
+
+.tooltip {
+  display: block !important;
+  z-index: 88888;
+}
+
+.tooltip .tooltip-inner {
+}
+
+.tooltip.popover .popover-inner {
+}
+
+.tooltip[aria-hidden='true'] {
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.15s, visibility 0.15s;
+}
+
+.tooltip[aria-hidden='false'] {
+  visibility: visible;
+  opacity: 1;
+  transition: opacity 0.15s;
+}
 
 /* Show/Hide Transition
 ---------------------------------------------------------------------------- */

--- a/assets/src/components.js
+++ b/assets/src/components.js
@@ -39,6 +39,8 @@ import ResourceTableRow from '@/components/Index/ResourceTableRow';
 import SearchInput from '@/components/SearchInput';
 import SelectControl from '@/components/Controls/SelectControl';
 import SortableIcon from '@/components/Index/SortableIcon';
+import Tooltip from '@/components/Tooltip';
+import TooltipContent from '@/components/TooltipContent';
 import TrendMetric from '@/components/Metrics/TrendMetric';
 import ValidationErrors from '@/components/ValidationErrors';
 import ValueMetric from '@/components/Metrics/ValueMetric';
@@ -97,6 +99,9 @@ Vue.component('search-input', SearchInput);
 Vue.component('select-control', SelectControl);
 Vue.component('sortable-icon', SortableIcon);
 Vue.component('text-field-filter', TextFieldFilter);
+Vue.component('tooltip', Tooltip);
+Vue.component('tooltip-content', TooltipContent);
+
 Vue.component('trend-metric', TrendMetric);
 Vue.component('value-metric', ValueMetric);
 Vue.component('validation-errors', ValidationErrors);

--- a/assets/src/components/Detail/BooleanGroup.vue
+++ b/assets/src/components/Detail/BooleanGroup.vue
@@ -1,0 +1,72 @@
+<template>
+  <panel-item :field="field">
+    <template slot="value">
+      <ul
+        v-if="value.length > 0"
+        class="list-reset"
+      >
+        <li
+          v-for="option in value"
+          :key="option.name"
+          class="mb-1"
+        >
+          <span
+            :class="classes[option.checked]"
+            class="inline-flex items-center py-1 pl-2 pr-3 rounded-full font-bold text-sm leading-tight"
+          >
+            <fake-checkbox
+              :checked="option.checked"
+              width="20"
+              height="20"
+            />
+            <span class="ml-1">{{ option.label }}</span>
+          </span>
+        </li>
+      </ul>
+      <span v-else>{{ field.options.no_value || "No Data" }}</span>
+    </template>
+  </panel-item>
+</template>
+
+<script>
+export default {
+  props: {
+    resourceName: {
+      type: String,
+      required: true
+    },
+    resourceId: {
+      type: [ String, Number ],
+      required: true
+    },
+    resource: {
+      type: Object,
+      required: true
+    },
+    field: {
+      type: Object,
+      required: true
+    }
+  },
+
+  data: () => ({
+    value: [],
+    classes: {
+      true: 'bg-success-light text-success-dark',
+      false: 'bg-danger-light text-danger-dark',
+    },
+  }),
+
+  created () {
+    this.field.value = this.field.value || {};
+    const options = this.field.options.group_options || {};
+    this.value = Object.keys(options).map(name => {
+      return {
+        name: name,
+        label: options[name],
+        checked: this.field.value[name] || false
+      };
+    });
+  },
+};
+</script>

--- a/assets/src/components/Form/BooleanGroup.vue
+++ b/assets/src/components/Form/BooleanGroup.vue
@@ -1,0 +1,81 @@
+<template>
+  <default-field
+    :field="field"
+    :errors="errors"
+  >
+    <template slot="field">
+      <checkbox-with-label
+        v-for="option in value"
+        :key="option.name"
+        class="mt-2"
+        :name="option.name"
+        :checked="option.checked"
+        @change="toggle($event, option)"
+      >
+        {{ option.label }}
+      </checkbox-with-label>
+    </template>
+  </default-field>
+</template>
+
+<script>
+import { Errors, FormField, HandlesValidationErrors } from 'ex-teal-js';
+import _ from 'lodash';
+export default {
+  mixins: [ HandlesValidationErrors, FormField ],
+
+  data: () => ({
+    value: [],
+  }),
+
+  computed: {
+    /**
+     * Return the final filtered json object
+     */
+    finalPayload () {
+      return _(this.value)
+        .map(o => [ o.name, o.checked ])
+        .fromPairs()
+        .value();
+    },
+  },
+
+  methods: {
+    /*
+     * Set the initial value for the field
+     */
+    setInitialValue () {
+      this.field.value = this.field.value || {};
+      const options = this.field.options.group_options || {};
+      this.value = Object.keys(options).map(name => { 
+        return {
+          name: name,
+          label: options[name],
+          checked: this.field.value[name] || false
+        };
+      });
+    },
+
+    /**
+     * Provide a function that fills a passed FormData object with the
+     * field's internal value attribute.
+     */
+    fill (formData) {
+      formData.append(this.field.attribute, JSON.stringify(this.finalPayload));
+    },
+
+    /**
+     * Toggle the option's value.
+     */
+    toggle (event, option) {
+      const firstOption = this.value.find(o => o.name == option.name);
+
+      if(!firstOption) {
+        this.value[option.name] = event.target.checked;
+      } else {
+        firstOption.checked = event.target.checked;
+      }
+    },
+  },
+};
+</script>

--- a/assets/src/components/Index/BooleanGroup.vue
+++ b/assets/src/components/Index/BooleanGroup.vue
@@ -1,0 +1,66 @@
+<template>
+  <div :class="`text-${field.textAlign}`">
+    <tooltip trigger="click">
+      <div class="text-primary inline-flex items-center dim cursor-pointer">
+        <span class="text-primary font-bold">View</span>
+      </div>
+
+      <tooltip-content slot="content">
+        <ul
+          v-if="value.length > 0"
+          class="list-reset"
+        >
+          <li
+            v-for="option in value"
+            :key="option.name"
+            class="mb-1"
+          >
+            <span
+              :class="classes[option.checked]"
+              class="inline-flex items-center py-1 pl-2 pr-3 rounded-full font-bold text-sm leading-tight"
+            >
+              <fake-checkbox
+                :checked="option.checked"
+                width="20"
+                height="20"
+              />
+              <span class="ml-1">{{ option.label }}</span>
+            </span>
+          </li>
+        </ul>
+        <span v-else>{{ field.options.no_value || "No Data" }}</span>
+      </tooltip-content>
+    </tooltip>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    field: {
+      type: Object,
+      required: true
+    }
+  },
+
+  data: () => ({
+    value: [],
+    classes: {
+      true: 'bg-success-light text-success-dark',
+      false: 'bg-danger-light text-danger-dark',
+    },
+  }),
+
+  created () {
+    this.field.value = this.field.value || {};
+    const options = this.field.options.group_options || {};
+    this.value = Object.keys(options).map(name => {
+      return {
+        name: name,
+        label: options[name],
+        checked: this.field.value[name] || false
+      };
+    });
+  }
+};
+</script>

--- a/assets/src/components/Tooltip.vue
+++ b/assets/src/components/Tooltip.vue
@@ -1,0 +1,45 @@
+<script>
+export default {
+  props: {
+    offset: {
+      type: [ Number, String ],
+      default: 3,
+    },
+
+    trigger: {
+      default: 'hover',
+      validator: val => [ 'click', 'hover' ].includes(val),
+    },
+
+    placement: {
+      type: String,
+      default: 'top',
+    },
+
+    boundary: {
+      type: String,
+      default: 'window',
+    },
+  },
+
+  render (h) {
+    return (
+      <v-popover
+        trigger={this.trigger}
+        offset={this.offset}
+        placement={this.placement}
+        boundariesElement={this.boundary}
+        popoverClass="z-50"
+        popoverBaseClass=""
+        popoverWrapperClass=""
+        popoverArrowClass=""
+        popoverInnerClass=""
+      >
+        <span>{this.$slots.default}</span>
+
+        <template slot="popover">{this.$slots.content}</template>
+      </v-popover>
+    );
+  },
+};
+</script>

--- a/assets/src/components/TooltipContent.vue
+++ b/assets/src/components/TooltipContent.vue
@@ -1,0 +1,24 @@
+<script>
+const defaultClasses =
+  'bg-white px-3 py-2 rounded border border-50 shadow text-sm leading-normal';
+
+export default {
+  props: {
+    maxWidth: {
+      default: 'auto',
+      type: String
+    },
+  },
+
+  render (h) {
+    return (
+      <div
+        class={this.$props.class || defaultClasses}
+        style={`max-width: ${this.maxWidth}px`}
+      >
+        {this.$slots.default}
+      </div>
+    );
+  },
+};
+</script>

--- a/assets/src/fields.js
+++ b/assets/src/fields.js
@@ -171,3 +171,12 @@ import IndexColorField from '@/components/Index/Color.vue';
 Vue.component('form-color', FormColorField);
 Vue.component('detail-color', DetailColorField);
 Vue.component('index-color', IndexColorField);
+
+// BooleanGroup...
+import FormBooleanGroupField from '@/components/Form/BooleanGroup.vue';
+import DetailBooleanGroupField from '@/components/Detail/BooleanGroup.vue';
+import IndexBooleanGroupField from '@/components/Index/BooleanGroup.vue';
+
+Vue.component('form-boolean-group', FormBooleanGroupField);
+Vue.component('detail-boolean-group', DetailBooleanGroupField);
+Vue.component('index-boolean-group', IndexBooleanGroupField);

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -6097,6 +6097,11 @@ popper.js@^1.14.4:
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.15.0.tgz#5560b99bbad7647e9faa475c6b8056621f5a4ff2"
   integrity sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==
 
+popper.js@^1.16.0:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
+
 portal-vue@^1.3.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/portal-vue/-/portal-vue-1.5.1.tgz#6bed79ef168d9676bb79f41d43c5cd4cedf54dbc"
@@ -8211,6 +8216,15 @@ uuid@^3.0.1, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
+v-tooltip@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/v-tooltip/-/v-tooltip-2.0.3.tgz#34fd64096656f032b1616567bf62f6165c57d529"
+  integrity sha512-KZZY3s+dcijzZmV2qoDH4rYmjMZ9YKGBVoUznZKQX0e3c2GjpJm3Sldzz8HHH2Ud87JqhZPB4+4gyKZ6m98cKQ==
+  dependencies:
+    lodash "^4.17.15"
+    popper.js "^1.16.0"
+    vue-resize "^0.4.5"
+
 v8-compile-cache@^2.0.2:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
@@ -8317,6 +8331,11 @@ vue-multiselect@^2.1.3:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/vue-multiselect/-/vue-multiselect-2.1.6.tgz#5be5d811a224804a15c43a4edbb7485028a89c7f"
   integrity sha512-s7jmZPlm9FeueJg1RwJtnE9KNPtME/7C8uRWSfp9/yEN4M8XcS/d+bddoyVwVnvFyRh9msFo0HWeW0vTL8Qv+w==
+
+vue-resize@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/vue-resize/-/vue-resize-0.4.5.tgz#4777a23042e3c05620d9cbda01c0b3cc5e32dcea"
+  integrity sha512-bhP7MlgJQ8TIkZJXAfDf78uJO+mEI3CaLABLjv0WNzr4CcGRGPIAItyWYnP6LsPA4Oq0WE+suidNs6dgpO4RHg==
 
 vue-router@^3.0.1:
   version "3.1.3"

--- a/lib/ex_teal/field.ex
+++ b/lib/ex_teal/field.ex
@@ -43,6 +43,10 @@ defmodule ExTeal.Field do
 
   @callback filterable_as :: ExTeal.FieldFilter.valid_type()
 
+  @callback default_sortable :: boolean()
+
+  @callback sanitize_as :: atom() | false
+
   defmacro __using__(_opts) do
     quote do
       @behaviour ExTeal.Field

--- a/lib/ex_teal/fields/boolean_group.ex
+++ b/lib/ex_teal/fields/boolean_group.ex
@@ -1,0 +1,125 @@
+defmodule ExTeal.Fields.BooleanGroup do
+  @moduledoc """
+  A group of boolean inputs that represent a map, or embedded schema
+  where each value is a boolean.  Useful for embedding features, permissions,
+  or roles into a schema.
+
+  If the field represents and embedded schema as an `embeds_one`, the field
+  will set a default set of options based on the fields of the embedded schema.
+  It assumes that every field in the embed is a boolean:
+
+      defmodule Permissions do
+        use Ecto.Schema
+
+        embedded_schema do
+          field :read, :boolean, default: false
+          field :write, :boolean, default: false
+          field :delete, :boolean, default: false
+        end
+
+        def changeset(permissions, attrs) do
+          cast(permission, attrs, [:read, :write, :delete])
+        end
+      end
+
+      defmodule Post do
+        use Ecto.Schema
+
+        schema "posts" do
+          field :title, :string
+          embeds_one :permissions, Permissions
+        end
+      end
+
+
+      def PostResource do
+        use ExTeal.Resource
+        def model, do: Post
+
+        def fields, do: [
+          Text.make(:title),
+          BooleanGroup.make(:permissions)
+        ]
+      end
+
+  You can also define a boolean group over a plain map type and manually
+  define the options as a map of keys and labels:
+
+      defmodule Post do
+        use Ecto.Schema
+
+        schema "posts" do
+          field :title, :string
+          field :permissions, :map
+        end
+      end
+
+      def PostResource do
+        use ExTeal.Resource
+        def model, do: Post
+
+        def fields, do: [
+          Text.make(:title),
+          BooleanGroup.make(:permissions)
+          |> BooleanGroup.options(%{
+            "read" => "Read",
+            "write" => "Write"
+          })
+        ]
+      end
+
+  The `options` function can also be used to override the default options
+  when used with an embedded schema if the options need to be translated into
+  human readable values.
+  """
+
+  use ExTeal.Field
+  alias ExTeal.Field
+
+  def component, do: "boolean-group"
+
+  @impl true
+  def default_sortable, do: false
+
+  @impl true
+  def apply_options_for(field, model, _type) do
+    schema = model.__struct__
+
+    case schema.__schema__(:type, field.field) do
+      :map ->
+        field
+
+      {:embed, embedded} ->
+        fields = embedded.related.__schema__(:fields)
+
+        opts =
+          (fields -- [:id])
+          |> Enum.into(%{}, fn f ->
+            field_string = Atom.to_string(f)
+            {field_string, field_string}
+          end)
+
+        options(field, opts)
+    end
+  end
+
+  @impl true
+  def sanitize_as, do: :json
+
+  @doc """
+  Add the available options to manage in the boolean group
+  """
+  @spec options(Field.t(), map()) :: Field.t()
+  def options(field, options) do
+    opts = Map.merge(options, %{group_options: options})
+    %{field | options: opts}
+  end
+
+  @doc """
+  Customize the text displayed in the event that a field contains no values.
+  """
+  @spec no_value_text(Field.t(), String.t()) :: Field.t()
+  def no_value_text(field, text) do
+    %{field | options: Map.put(field.options, :no_value, text)}
+  end
+end

--- a/lib/ex_teal/resource/attributes.ex
+++ b/lib/ex_teal/resource/attributes.ex
@@ -66,7 +66,10 @@ defmodule ExTeal.Resource.Attributes do
           Attributes.maybe_sanitize(attrs, fields, skip_sanitize)
         end
 
-        defoverridable permitted_attributes: 3
+        def parse(param) do
+        end
+
+        defoverridable permitted_attributes: 3, parse: 1
       end
     end
   end
@@ -111,6 +114,10 @@ defmodule ExTeal.Resource.Attributes do
 
   @valid_sanitizers ~w(noscrub basic_html html5 markdown_html strip_tags)a
   def sanitize(false, value), do: value
+
+  def sanitize(:json, value) do
+    Jason.decode!(value)
+  end
 
   def sanitize(key, value) when is_atom(key) and key in @valid_sanitizers do
     apply(HtmlSanitizeEx, key, [value])

--- a/lib/ex_teal/resource/create.ex
+++ b/lib/ex_teal/resource/create.ex
@@ -32,7 +32,7 @@ defmodule ExTeal.Resource.Create do
   `handle_create/2` can return an %Ecto.Changeset, an Ecto.Schema struct,
   a list of errors (`{:error, [email: "is not valid"]}` or a conn with
   any response/body.
-
+  ou
   Example custom implementation:
 
       def handle_create(_conn, attributes) do


### PR DESCRIPTION
Adds a new Boolean Group Field to Teal:

### Screenshots
<img width="690" alt="Screen Shot 2020-08-24 at 10 47 11 AM" src="https://user-images.githubusercontent.com/2738409/91059115-4ffec180-e5f7-11ea-9278-d616f03de2ae.png">
<img width="684" alt="Screen Shot 2020-08-24 at 10 47 17 AM" src="https://user-images.githubusercontent.com/2738409/91059123-51c88500-e5f7-11ea-87a0-92fb5d250e07.png">
<img width="1037" alt="Screen Shot 2020-08-24 at 10 47 28 AM" src="https://user-images.githubusercontent.com/2738409/91059128-52f9b200-e5f7-11ea-9da3-d1b562af73d5.png">

### Details


A group of boolean inputs that represent a map, or embedded schema
  where each value is a boolean.  Useful for embedding features, permissions,
  or roles into a schema.

  If the field represents and embedded schema as an `embeds_one`, the field
  will set a default set of options based on the fields of the embedded schema.
  It assumes that every field in the embed is a boolean:

```elixir
defmodule Permissions do
  use Ecto.Schema

  embedded_schema do
    field :read, :boolean, default: false
    field :write, :boolean, default: false
    field :delete, :boolean, default: false
  end

  def changeset(permissions, attrs) do
    cast(permission, attrs, [:read, :write, :delete])
  end
end

defmodule Post do
  use Ecto.Schema

  schema "posts" do
    field :title, :string
    embeds_one :permissions, Permissions
  end
end


def PostResource do
  use ExTeal.Resource
  def model, do: Post

  def fields, do: [
    Text.make(:title),
    BooleanGroup.make(:permissions)
  ]
end
```

  You can also define a boolean group over a plain map type and manually
  define the options as a map of keys and labels:
```elixir
defmodule Post do
  use Ecto.Schema

  schema "posts" do
    field :title, :string
    field :permissions, :map
  end
end

def PostResource do
  use ExTeal.Resource
  def model, do: Post

  def fields, do: [
    Text.make(:title),
    BooleanGroup.make(:permissions)
    |> BooleanGroup.options(%{
      "read" => "Read",
      "write" => "Write"
    })
  ]
end
```
  The `options` function can also be used to override the default options
  when used with an embedded schema if the options need to be translated into
  human readable values.