### PR TITLE
fix: Card Wrapper xl window size was being purged

### DIFF
--- a/assets/src/components/CardWrapper.vue
+++ b/assets/src/components/CardWrapper.vue
@@ -45,7 +45,7 @@ export default {
 
   computed: {
     widthClass () {
-      return this.size == 'large' ? 'w-full' : calculateCardWidth(this.card);
+      return this.card.width == 'full' ? 'w-full' : calculateCardWidth(this.card);
     },
 
     cardSizeClass () {
@@ -64,22 +64,22 @@ function calculateCardWidth (card) {
 
   switch (card.width) {
     case '1/2':
-      width = 'w-1/2';
+      width = 'xl:w-1/2';
       break;
     case '1/3':
-      width = 'w-1/3';
+      width = 'xl:w-1/3';
       break;
     case '2/3':
-      width = 'w-2/3';
+      width = 'xl:w-2/3';
       break;
     case '1/4':
-      width = 'w-1/4';
+      width = 'xl:w-1/4';
       break;
     case '3/4':
-      width = 'w-3/4';
+      width = 'xl:w-3/4';
       break;
   }
 
-  return `w-full lg:w-1/2 xl:${width}`;
+  return `w-full lg:w-1/2 ${width}`;
 }
 </script>

--- a/lib/ex_teal/help_card.ex
+++ b/lib/ex_teal/help_card.ex
@@ -5,7 +5,9 @@ defmodule ExTeal.HelpCard do
 
   use ExTeal.Card
 
+  @impl true
   def width, do: "full"
 
+  @impl true
   def component, do: "help-card"
 end


### PR DESCRIPTION
<img width="1102" alt="Screen Shot 2020-09-16 at 9 46 39 AM" src="https://user-images.githubusercontent.com/2738409/93346051-8ba93780-f801-11ea-9b16-fce1188bc043.png">


This PR fixes the card sizes by using the correct width definition and explicitly listing the `xl` widths so that they are not purged.