### PR TITLE
feat: Naive DateTimes

### DIFF
--- a/assets/src/assets/css/main.css
+++ b/assets/src/assets/css/main.css
@@ -193,7 +193,7 @@ textarea, select, input, button, .checkbox { outline: none; z-index: 10}
 }
 
 .form-input {
-  @apply .bg-white .border .border-white .px-2 .text-gray-darker;
+  @apply .bg-white .border .border-white .px-2 .text-gray-darkest;
 }
 
 .form-control-focus {
@@ -210,7 +210,7 @@ textarea, select, input, button, .checkbox { outline: none; z-index: 10}
 }
 
 .form-input-bordered {
-  @apply .bg-white .border .border-gray-dark .px-2 .text-gray-darker;
+  @apply .bg-white .border .border-gray-dark .px-2 .text-gray-darkest;
 }
 
 .form-input.search {
@@ -218,7 +218,7 @@ textarea, select, input, button, .checkbox { outline: none; z-index: 10}
 }
 
 .form-select {
-  @apply .bg-white .border .pl-3 .pr-8 .text-black .shadow;
+  @apply .bg-white .border .pl-3 .pr-8 .text-black .border-gray-dark;
   appearance: none;
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z' stroke='%239fa6b2' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;

--- a/assets/src/components/Form/DateTime.vue
+++ b/assets/src/components/Form/DateTime.vue
@@ -11,6 +11,7 @@
         class="w-full form-control form-input form-input-bordered"
         :date-format="pickerFormat"
         :placeholder="placeholder"
+        :twelve-hour-time="twelveHourTime"
         @change="handleChange"
       />
     </template>
@@ -39,6 +40,10 @@ export default {
 
     pickerFormat () {
       return this.field.options.picker_format || 'Y-m-d H:i:S';
+    },
+
+    twelveHourTime () {
+      return !this.field.options.twenty_four_hour_time || true;
     }
   },
 
@@ -48,16 +53,32 @@ export default {
 
       if (this.value !== '') {
         this.localizedValue = this.fromUTC(this.value);
+        return;
+      }
+
+      if (this.naiveDateTime) {
+        this.localizedValue = this.value;
       }
     },
 
     handleChange (value) {
+      if (this.naiveDateTime) {
+        const now = DateTime.local();
+        const dt = DateTime.fromISO(value).setZone(now.zoneName, {
+          keepLocalTime: true
+        });
+
+        this.value = `${dt.toFormat('yyyy-M-dd')}T${dt.toFormat('TT')}`;
+        this.localizedValue = dt.toLocaleString(DateTime.DATETIME_MED);
+
+        return;
+      }
       this.value = value;
       this.localizedValue = this.fromUTC(this.value);
     },
 
     fromUTC (value) {
-      return DateTime.fromISO(this.value).toLocaleString(DateTime.DATETIME_FULL);
+      return DateTime.fromISO(value).toLocaleString(DateTime.DATETIME_FULL);
     }
   }
 };

--- a/assets/src/mixins/InteractsWithDateTimes.js
+++ b/assets/src/mixins/InteractsWithDateTimes.js
@@ -26,13 +26,16 @@ const formatKeys = {
 const InteractsWithDateTimes = {
   computed: {
     format () {
-      if (!this.field.options.format) {
-        return DateTime.DATE_FULL;
-      }
-      return formatKeys[this.field.options.format] || formatKeys['datetime_short'];
+      const key = this.naiveDateTime ? 'datetime_med' : 'datetime_full';
+      return this.field.options.format ? formatKeys[this.field.options.format] : formatKeys[key];
+    },
+
+    naiveDateTime () {
+      return this.field.options.naive_datetime || false;
     },
 
     formattedDate () {
+
       return DateTime.fromISO(this.field.value).toLocaleString(this.format);
     }
   }

--- a/lib/ex_teal/fields/date_time.ex
+++ b/lib/ex_teal/fields/date_time.ex
@@ -5,8 +5,6 @@ defmodule ExTeal.Fields.DateTime do
 
   def component, do: "date-time"
 
-  def filterable_as, do: ExTeal.FieldFilter.DateTime
-
   @doc """
   Set the format of the flatpickr datetime picker.
 
@@ -44,7 +42,7 @@ defmodule ExTeal.Fields.DateTime do
   en_US -> Oct 14, 1983
   fr    -> 14 oct. 1983
 
-  :full 
+  :full
   en_US -> October 14, 1983
   fr    -> 14 octobre 1983
 
@@ -56,13 +54,25 @@ defmodule ExTeal.Fields.DateTime do
     %{field | options: Map.put_new(options, :format, value)}
   end
 
+  @doc """
+  Specify that the field is a naive datetime.  Using this function, the field
+  will render and set the value without converting from the users local time
+  to UTC.
+  """
+  def naive_datetime(%Field{options: options} = field),
+    do: %{field | options: Map.put_new(options, :naive_datetime, true)}
+
+  @impl true
+  def filterable_as, do: ExTeal.FieldFilter.DateTime
+
+  @impl true
   def value_for(%Field{} = field, model, _view) do
     case Map.get(model, field.field) do
       nil ->
         nil
 
       %NaiveDateTime{} = naive ->
-        DateTime.from_naive!(naive, "Etc/UTC", Tzdata.TimeZoneDatabase)
+        naive
 
       val ->
         val


### PR DESCRIPTION
This PR adds a feature to the `DateTime` field which allows it to better handle
naive datetimes by disregarding timezones and allowing the user and Vue app to
render and manipulate the field's value without considering the browsers
timezone or UTC time.

It also cleans up some invalid props passed to the datetime picker and ensures a
better default for DateTime formatting when a specific format is not specified.

Finally, it cleans up the borders and font colors of the input fields to offer
better contrast.


### Screenshots

#### Form View:
<img width="645" alt="Screen Shot 2020-10-30 at 4 55 33 PM" src="https://user-images.githubusercontent.com/2738409/97756209-e4424480-1ad0-11eb-8b91-fc59e58a23cc.png">

#### Index View:
<img width="556" alt="Screen Shot 2020-10-30 at 4 55 40 PM" src="https://user-images.githubusercontent.com/2738409/97756222-e906f880-1ad0-11eb-8991-cfe837d0eeb0.png">

#### Detail View
<img width="672" alt="Screen Shot 2020-10-30 at 4 55 28 PM" src="https://user-images.githubusercontent.com/2738409/97756186-db517300-1ad0-11eb-8583-90cb25c0e4f8.png">


<img width="338" alt="Screen Shot 2020-10-30 at 4 55 50 PM" src="https://user-images.githubusercontent.com/2738409/97756228-eb695280-1ad0-11eb-80a3-eba2c82fcb09.png">
<img width="661" alt="Screen Shot 2020-10-30 at 4 56 00 PM" src="https://user-images.githubusercontent.com/2738409/97756233-ee644300-1ad0-11eb-8155-3aca9e2ba752.png">




