### PR TITLE
fix: Naive DateTime Selector

### DIFF
--- a/assets/src/components/DateTimePicker.vue
+++ b/assets/src/components/DateTimePicker.vue
@@ -62,10 +62,8 @@ export default {
         enableSeconds: this.enableSeconds,
         onClose: this.onChange,
         dateFormat: 'Z',
-        allowInput: true,
         altInput: true,
         altFormat: this.dateFormat,
-
         time_24hr: !this.twelveHourTime
       });
     });

--- a/assets/src/components/Form/DateTime.vue
+++ b/assets/src/components/Form/DateTime.vue
@@ -7,7 +7,7 @@
       <DateTimePicker
         :field="field"
         :field-name="field.name"
-        :value="localizedValue"
+        :value="value"
         class="w-full form-control form-input form-input-bordered"
         :date-format="pickerFormat"
         :placeholder="placeholder"
@@ -26,8 +26,6 @@ export default {
   components: { DateTimePicker },
   mixins: [ HandlesValidationErrors, FormField ],
 
-  data: () => ({ localizedValue: '' }),
-
   computed: {
     format () {
       return this.field.options.format || DateTime.DATETIME_FULL;
@@ -44,6 +42,10 @@ export default {
 
     twelveHourTime () {
       return !this.field.options.twenty_four_hour_time || true;
+    },
+
+    naiveDateTime () {
+      return this.field.options.naive_datetime || false;
     }
   },
 
@@ -52,33 +54,18 @@ export default {
       this.value = this.field.value || '';
 
       if (this.value !== '') {
-        this.localizedValue = this.fromUTC(this.value);
         return;
-      }
-
-      if (this.naiveDateTime) {
-        this.localizedValue = this.value;
       }
     },
 
     handleChange (value) {
       if (this.naiveDateTime) {
         const now = DateTime.local();
-        const dt = DateTime.fromISO(value).setZone(now.zoneName, {
-          keepLocalTime: true
-        });
-
+        const dt = DateTime.fromISO(value).setZone(now.zoneName);
         this.value = `${dt.toFormat('yyyy-M-dd')}T${dt.toFormat('TT')}`;
-        this.localizedValue = dt.toLocaleString(DateTime.DATETIME_MED);
-
         return;
       }
       this.value = value;
-      this.localizedValue = this.fromUTC(this.value);
-    },
-
-    fromUTC (value) {
-      return DateTime.fromISO(value).toLocaleString(DateTime.DATETIME_FULL);
     }
   }
 };

--- a/lib/ex_teal/fields/date_time.ex
+++ b/lib/ex_teal/fields/date_time.ex
@@ -72,7 +72,11 @@ defmodule ExTeal.Fields.DateTime do
         nil
 
       %NaiveDateTime{} = naive ->
-        naive
+        if Map.get(field.options, :naive_datetime) do
+          naive
+        else
+          DateTime.from_naive!(naive, "Etc/UTC")
+        end
 
       val ->
         val


### PR DESCRIPTION
Applies three changes to the `DateTime` field:

- Ensures the form field is readonly, due to a two way data bug in flatpickr, luxon and vue.
- Removes localized values and ensure that the time selected by a naive datetime field is translated back to a local naive datetime.
- Date Time fields that represent a naive datetime should translate the value to a utc-zoned field, to sync with ecto standards.