### PR TITLE
feat: BelongsTo should always be searchable

### DIFF
--- a/assets/src/components/Form/BelongsTo.vue
+++ b/assets/src/components/Form/BelongsTo.vue
@@ -2,7 +2,7 @@
   <default-field :field="field">
     <template slot="field">
       <search-input
-        v-if="isSearchable && !isLocked"
+        v-if="!isLocked"
         :error="hasError"
         :value="selectedResource"
         :data="availableResources"
@@ -68,30 +68,6 @@
           </div>
         </div>
       </search-input>
-      <select
-        v-else
-        :class="{ 'border-danger': hasError }"
-        :disabled="isLocked"
-        class="form-control form-select mb-3 w-full"
-        @change="selectResourceFromSelectControl"
-      >
-        <option
-          value=""
-          selected
-        >
-          Choose {{ field.name }}
-        </option>
-
-        <option
-          v-for="resource in availableResources"
-          :key="resource.id"
-          :value="resource.id"
-          :selected="selectedResourceId == resource.id"
-        >
-          {{ resource.title }}
-        </option>
-      </select>
-
       <p
         v-if="hasError"
         class="my-2 text-danger"
@@ -168,13 +144,6 @@ export default {
     },
 
     /**
-     * Determine if the related resources is searchable
-     */
-    isSearchable () {
-      return this.field.options.searchable;
-    },
-
-    /**
      * Get the query params for getting available resources
      */
     queryParams () {
@@ -217,21 +186,12 @@ export default {
         this.selectedResourceId = this.viaResourceId;
       }
 
-      if (this.shouldSelectInitialResource && !this.isSearchable) {
-        // If we should select the initial resource but the field is not
-        // searchable we should load all of the available resources into the
-        // field first and select the initial option
-        this.initializingWithExistingResource = false;
-        this.getAvailableResources().then(() => this.selectInitialResource());
-      } else if (this.shouldSelectInitialResource && this.isSearchable) {
+      if (this.shouldSelectInitialResource) {
         // If we should select the initial resource and the field is
         // searchable, we won't load all the resources but we will select
         // the initial option
         this.getAvailableResources().then(() => this.selectInitialResource());
-      } else if (!this.shouldSelectInitialResource && !this.isSearchable) {
-        // If we don't need to select an initial resource because the user
-        // came to create a resource directly and there's no parent resource,
-        // and the field is searchable we'll just load all of the resources
+      } else {
         this.getAvailableResources();
       }
 
@@ -243,14 +203,6 @@ export default {
         `/api/${resourceName}/relatable/${attribute}`,
         params
       );
-    },
-
-    /**
-     * Select a resource using the <select> control
-     */
-    selectResourceFromSelectControl (e) {
-      this.selectedResourceId = e.target.value;
-      this.selectInitialResource();
     },
 
     /**

--- a/lib/ex_teal/fields/belongs_to.ex
+++ b/lib/ex_teal/fields/belongs_to.ex
@@ -69,7 +69,7 @@ defmodule ExTeal.Fields.BelongsTo do
   """
   @spec searchable(Field.t()) :: Field.t()
   def searchable(field) do
-    opts = Map.merge(field.options, %{searchable: true})
-    Map.put(field, :options, opts)
+    IO.warn("searchable/1 is deprecated.  BelongsTo fields are always searchable")
+    field
   end
 end


### PR DESCRIPTION
We ran into some strange performance projects on a client project that
was later identified as a non-searchable belongs to field timing out
requests for update and creation fields by attempting to serialize the
entire contents of a table with hundreds of thousands of rows in it.

Obviously this is not a good thing.

There are very few use cases where a belongs to with a fixed, small
collection of potential relationships is desirable.  This commit
removes that default and adds a warning to the `BelongsTo.searchable`
function.