### PR TITLE
fix: cast fields to string for simple search

### DIFF
--- a/lib/ex_teal/search/simple_search.ex
+++ b/lib/ex_teal/search/simple_search.ex
@@ -13,21 +13,9 @@ defmodule ExTeal.Search.SimpleSearch do
   @spec build(Ecto.Query.t(), module(), map()) :: Ecto.Query.t()
   def build(query, resource, %{"search" => term}) do
     dynamic =
-      Enum.reduce(resource.search(), false, fn field_name, dynamic ->
-        dynamic([q], ilike(field(q, ^field_name), ^"%#{term}%") or ^dynamic)
+      Enum.reduce([:id | resource.search()], false, fn field_name, dynamic ->
+        dynamic([q], ilike(type(field(q, ^field_name), :string), ^"%#{term}%") or ^dynamic)
       end)
-
-    dynamic =
-      case Integer.parse(term) do
-        {id, ""} ->
-          dynamic([q], q.id == ^id or ^dynamic)
-
-        {_integer, _remainder} ->
-          dynamic
-
-        :error ->
-          dynamic
-      end
 
     from(query, where: ^dynamic)
   end


### PR DESCRIPTION
I knew that type casting could happen on the right hand side of the =, but not on the left.  I came across this: https://stackoverflow.com/questions/25528780/pg-query-query-failed-error-operator-does-not-exist-integer-unknown-n

it feels like casting everything to string and adding :id into the mix at all times.. makes sense for simple search?