### PR TITLE
fix: Number fields are now represented as string fields

### DIFF
--- a/assets/src/views/Index.vue
+++ b/assets/src/views/Index.vue
@@ -736,7 +736,7 @@ export default {
           });
 
           this.resourcesToSort = _.sortBy(this.resources, resource => {
-            return resource.fields[index].value;
+            return parseInt(resource.fields[index].value);
           });
 
           this.isSorting = true;


### PR DESCRIPTION
Reordering index tables was broken because the new number serialization resulted in the rows being reordered by their string representation of the order value.