### PR TITLE
feat: Select fields can represent Ecto.Enums

### DIFF
--- a/test/ex_teal/fields/select_test.exs
+++ b/test/ex_teal/fields/select_test.exs
@@ -1,5 +1,5 @@
 defmodule ExTeal.Fields.SelectTest do
-  use ExUnit.Case
+  use TestExTeal.ConnCase
 
   alias ExTeal.Fields.Select
 
@@ -34,6 +34,20 @@ defmodule ExTeal.Fields.SelectTest do
       field = Select.make(:size) |> Select.options(~w(S M L))
       model = %{size: "S"}
       assert Select.value_for(field, model, :show) == "S"
+    end
+
+    test "returns the value for a field that represents an ecto enum" do
+      field = Select.make(:role)
+      model = build(:user, role: :seller)
+
+      assert Select.value_for(field, model, :show) == :seller
+    end
+
+    test "returns the value for a field that does not represent an ecto enum" do
+      field = Select.make(:author) |> Select.options(~w(foo bar))
+      model = build(:post, author: "foo")
+
+      assert Select.value_for(field, model, :show) == "foo"
     end
 
     test "returns the default value for edit" do
@@ -156,5 +170,21 @@ defmodule ExTeal.Fields.SelectTest do
   test "can be searchable" do
     field = Select.make(:foo) |> Select.searchable()
     assert field.options.searchable
+  end
+
+  describe "apply_options_for/3" do
+    test "a field that represents an enum has it's options set automatically" do
+      field = Select.make(:role)
+      model = build(:user, role: :seller)
+
+      updated_field = Select.apply_options_for(field, model, :show)
+
+      assert updated_field.options.field_options == [
+               %{disabled: false, value: :admin, key: :admin},
+               %{disabled: false, value: :moderator, key: :moderator},
+               %{disabled: false, value: :seller, key: :seller},
+               %{disabled: false, value: :buyer, key: :buyer}
+             ]
+    end
   end
 end

--- a/test/support/factories.ex
+++ b/test/support/factories.ex
@@ -8,7 +8,8 @@ defmodule TestExTeal.Factory do
   def user_factory do
     %User{
       name: "Motel ExTeal",
-      email: "teal@motel.is"
+      email: "teal@motel.is",
+      role: :admin
     }
   end
 

--- a/test/support/migrations.exs
+++ b/test/support/migrations.exs
@@ -2,10 +2,15 @@ defmodule TestExTeal.Migrations do
   use Ecto.Migration
 
   def change do
+    create_query = "CREATE TYPE user_role AS ENUM ('admin', 'moderator', 'seller', 'buyer')"
+    drop_query = "DROP TYPE user_role"
+    execute(create_query, drop_query)
+
     create table(:users) do
       add(:email, :string)
       add(:name, :string)
       add(:password_hash, :string)
+      add(:role, :user_role)
       timestamps()
     end
 

--- a/test/support/resources.exs
+++ b/test/support/resources.exs
@@ -1,7 +1,7 @@
 defmodule TestExTeal.UserResource do
   use ExTeal.Resource
 
-  alias ExTeal.Fields.{ID, ManyToMany, Number, Text}
+  alias ExTeal.Fields.{ID, ManyToMany, Number, Select, Text}
 
   def model, do: TestExTeal.User
 
@@ -17,6 +17,7 @@ defmodule TestExTeal.UserResource do
       ID.make(:id),
       Text.make(:name),
       Text.make(:email),
+      Select.make(:role),
       ManyToMany.make(:preferred_tags, TestExTeal.Tag)
       |> ManyToMany.with_pivot_fields([
         Number.make(:order),

--- a/test/support/schema.exs
+++ b/test/support/schema.exs
@@ -5,6 +5,7 @@ defmodule TestExTeal.User do
     field(:email, :string)
     field(:name, :string)
     has_many(:posts, TestExTeal.Post)
+    field(:role, Ecto.Enum, values: [:admin, :moderator, :seller, :buyer])
 
     many_to_many(:preferred_tags, TestExTeal.Tag, join_through: TestExTeal.PreferredTag)
     timestamps()


### PR DESCRIPTION
What changed?
=============

We introduce functionality that allows a `ExTeal.Fields.Select` to
represent a `Ecto.Enum` field.

Why was this change made?
=========================

One of the primary values of `Ecto.Enum` is that it allows you to keep
atom values in a field of a schema.  Previously, values stored as atoms
could never be correctly recalled in a Teal select field because it
always selected the current value from the list of options initated in
`Select.options/2`.

These changes allow for the Ecto.Enum to become the source of the
possible options for the select field, and ensures that the two always
coincide.