### PR TITLE
fix: show errors on array form

### DIFF
--- a/assets/src/components/Form/Array.vue
+++ b/assets/src/components/Form/Array.vue
@@ -82,6 +82,11 @@
           <icon type="create" />
         </a>
       </div>
+      <p
+        v-if="hasError"
+        class="my-2 text-danger"
+        v-html="firstError"
+      />
     </template>
   </default-field>
 </template>


### PR DESCRIPTION
This PR updates teal to show errors on the array form! Encountered while working on an FRB thing 😄 

<img width="1440" alt="Screen Shot 2021-08-10 at 4 47 30 PM" src="https://user-images.githubusercontent.com/8646176/128944668-23ccea47-ab76-4d43-ab0b-edaf82b1feee.png">
<img width="1437" alt="Screen Shot 2021-08-10 at 4 47 45 PM" src="https://user-images.githubusercontent.com/8646176/128944669-ec2d0b03-90f3-4825-8cca-8f696ded3c91.png">
