### PR TITLE
fix: show errors on form select

### DIFF
--- a/assets/src/components/Form/Select.vue
+++ b/assets/src/components/Form/Select.vue
@@ -35,6 +35,11 @@
         value-key="value"
         @change="handleChange"
       />    
+      <p
+        v-if="hasError"
+        class="my-2 text-danger"
+        v-html="firstError"
+      />
     </template>
   </default-field>
 </template>


### PR DESCRIPTION
This PR updates the form 'select' to show errors, as they didn't appear to do so previously.

See https://github.com/township-agency/debt_wizard/pull/284 for an example of this!

<img width="1604" alt="Screen Shot 2021-09-03 at 12 54 02 PM" src="https://user-images.githubusercontent.com/8646176/132053695-4152f79b-2902-4b4c-a5d9-2c6d476de33c.png">
