### PR TITLE
fix: array field wouldn't save empty value

### DIFF
--- a/assets/src/components/Form/Array.vue
+++ b/assets/src/components/Form/Array.vue
@@ -139,9 +139,13 @@ export default {
   mounted () {
     this.setInitialValue();
     this.field.fill = formData => {
-      this.items.forEach((item, i) => {
-        formData.append(`${this.field.attribute}[]`, item);
-      });
+      if (this.items.length == 0) {
+        formData.append(`${this.field.attribute}[]`, []);
+      } else {
+        this.items.forEach((item, i) => {
+          formData.append(`${this.field.attribute}[]`, item);
+        });
+      }
     };
   },
 


### PR DESCRIPTION
If you cleared the values in an array field the changes were not being persisted

because the array of values was empty and we were using a 'forEach', it would skip that block of code, I added an if to check if the items are empty and set the value to an empty array

https://user-images.githubusercontent.com/31930284/174352938-f1f60fda-24cd-4b7c-bee9-c6bc860bab1d.mov

