### PR TITLE
fix: Allow users to customize the singular name of a resource 

### DIFF
--- a/lib/ex_teal/resource.ex
+++ b/lib/ex_teal/resource.ex
@@ -1,8 +1,6 @@
 defmodule ExTeal.Resource do
   @type params :: map()
 
-  alias Phoenix.Naming
-
   @moduledoc """
   When used, includes all aspects of the functionality required to
   manage the resource.
@@ -114,12 +112,9 @@ defmodule ExTeal.Resource do
   end
 
   def to_json(resource, conn) do
-    singular =
-      resource.title() |> Inflex.underscore() |> Naming.humanize() |> Inflex.singularize()
-
     %{
       title: resource.title(),
-      singular: singular,
+      singular: resource.singular_title(),
       group: resource.nav_group(conn),
       uri: resource.uri(),
       hidden: resource.hide_from_nav(),

--- a/lib/ex_teal/resource/model.ex
+++ b/lib/ex_teal/resource/model.ex
@@ -30,6 +30,11 @@ defmodule ExTeal.Resource.Model do
   @callback title() :: String.t()
 
   @doc """
+  Returns the singularized version of the title to display on forms.
+  """
+  @callback singular_title() :: String.t()
+
+  @doc """
   Returns the uri to display in the side bar.
 
   Defaults to finding the uri from the resource modules name
@@ -76,6 +81,7 @@ defmodule ExTeal.Resource.Model do
       @behaviour ExTeal.Resource.Model
 
       alias ExTeal.Resource.Model
+      alias Phoenix.Naming
 
       @inferred_model Model.model_from_resource(__MODULE__)
       @inferred_title Model.title_from_resource(__MODULE__)
@@ -83,6 +89,10 @@ defmodule ExTeal.Resource.Model do
 
       def model, do: @inferred_model
       def title, do: @inferred_title
+
+      def singular_title,
+        do: title() |> Inflex.underscore() |> Naming.humanize() |> Inflex.singularize()
+
       def uri, do: @inferred_uri
       def title_for_schema(schema), do: Model.title_for_schema_from_struct(schema)
       def subtitle_for_schema(schema), do: nil
@@ -94,6 +104,7 @@ defmodule ExTeal.Resource.Model do
 
       defoverridable model: 0,
                      title: 0,
+                     singular_title: 0,
                      uri: 0,
                      title_for_schema: 1,
                      subtitle_for_schema: 1,

--- a/test/ex_teal/resource_test.exs
+++ b/test/ex_teal/resource_test.exs
@@ -13,6 +13,8 @@ defmodule ExTeal.ResourceTest do
     use ExTeal.Resource
 
     def nav_group(_), do: "Admin"
+
+    def singular_title, do: "Foo"
   end
 
   defmodule ExTealTest.TestResource do
@@ -54,7 +56,7 @@ defmodule ExTeal.ResourceTest do
                },
                %{
                  title: "Groups",
-                 singular: "Group",
+                 singular: "Foo",
                  uri: "groups",
                  group: "Admin",
                  hidden: false,


### PR DESCRIPTION
English is hard sometimes.  `Inflex` translates the singular version of `Series` to `Sery`.  Allow users to override the singular title of a resource.