### PR TITLE
fix: default panel title and flatten panels while sorting

### DIFF
--- a/lib/ex_teal/panel.ex
+++ b/lib/ex_teal/panel.ex
@@ -78,8 +78,7 @@ defmodule ExTeal.Panel do
   defp is_a_panel?(_), do: false
 
   def default_panel_name(resource) do
-    title = resource.title() |> String.capitalize() |> Inflex.singularize()
-    "#{title} Details"
+    "#{resource.singular_title()} Details"
   end
 
   defp default_panel_for(resource) do

--- a/lib/ex_teal/resource/index.ex
+++ b/lib/ex_teal/resource/index.ex
@@ -6,7 +6,7 @@ defmodule ExTeal.Resource.Index do
   alias Ecto.Association.ManyToMany
   alias ExTeal.{Field, FieldFilter}
   alias ExTeal.Fields.BelongsTo
-  alias ExTeal.Resource.Index
+  alias ExTeal.Resource.{Fields, Index}
 
   import Ecto.Query
 
@@ -163,7 +163,8 @@ defmodule ExTeal.Resource.Index do
           params,
         resource
       ) do
-    field = Enum.find(resource.fields(), &(&1.attribute == field))
+    fields = Fields.all_fields(resource)
+    field = Enum.find(fields, &(&1.attribute == field))
 
     case field do
       nil -> sort_by_pivot(query, params, resource)
@@ -173,7 +174,8 @@ defmodule ExTeal.Resource.Index do
 
   def sort(query, %{"order_by" => field, "order_by_direction" => dir}, resource)
       when not is_nil(field) and not is_nil(dir) do
-    field_struct = Enum.find(resource.fields(), &(&1.attribute == field))
+    fields = Fields.all_fields(resource)
+    field_struct = Enum.find(fields, &(&1.attribute == field))
     handle_sort(query, field_struct, String.to_existing_atom(field), dir)
   end
 

--- a/test/ex_teal/panel_test.exs
+++ b/test/ex_teal/panel_test.exs
@@ -9,6 +9,8 @@ defmodule ExTeal.PanelTest do
 
     def title, do: "Posts"
 
+    def singular_title, do: "Test Name"
+
     def fields,
       do: [
         Text.make(:name),
@@ -59,9 +61,9 @@ defmodule ExTeal.PanelTest do
   end
 
   describe "gather_panels/1" do
-    test "given a resource without panels, returns a single panel with the resource name" do
+    test "given a resource without panels, returns a single panel with the customized resource name" do
       panels = Panel.gather_panels(SimpleResource)
-      assert panels == [%Panel{key: :"post details", name: "Post Details"}]
+      assert panels == [%Panel{key: :"test name details", name: "Test Name Details"}]
     end
   end
 


### PR DESCRIPTION
* Default Panel should use the new singular_title/0 of a resource
* flatten panel fields when sorting an index request
