### PR TITLE
fix: Allow Distinct in `handle_index/2` callbacks

### DIFF
--- a/lib/ex_teal/resource/pagination.ex
+++ b/lib/ex_teal/resource/pagination.ex
@@ -3,6 +3,7 @@ defmodule ExTeal.Resource.Pagination do
   Used to build paginated views of resources
   """
   import Ecto.Query
+
   def paginate_query(query, conn, resource) do
     per_page = conn.params |> Map.get("per_page", "25") |> String.to_integer()
     page = conn.params |> Map.get("page", "1") |> String.to_integer()
@@ -10,10 +11,12 @@ defmodule ExTeal.Resource.Pagination do
     offset = (page - 1) * per_page
 
     data_query = from(query, limit: ^per_page, offset: ^offset)
+
     agg_query =
       query
       |> exclude(:preload)
       |> exclude(:select)
+
     agg_query = from(q in subquery(agg_query), select: count(q.id))
     all = resource.repo().one(agg_query)
 


### PR DESCRIPTION
This commit allows `handle_index/2` overrides on resources to invoke the
`distinct: true` handler and _also enable column sorting_.  Previously
the aggregation used to count up the total rows of a resource would fail
because the order_by columns must always appear in the select
statement when using `distinct: true`.  This commit replaces the helper
`Repo.aggregate/3` function with a subquery call that excludes
previously set `preload` and `select` statements.
