### PR TITLE
fix: Detail Page Cards

### DIFF
--- a/assets/src/views/Detail.vue
+++ b/assets/src/views/Detail.vue
@@ -156,6 +156,7 @@ export default {
   watch: {
     resourceName: function (newResource, oldResource) {
       if (newResource !== oldResource) {
+        this.initialLoading = true;
         this.initializeComponent();
       }
     },


### PR DESCRIPTION
Bug:
* Navigate to the detail page of a resource with detail cards.  
* Navigate to the detail page of a different resource (ie via belongs to link)
* Teal throws a 'Not Found' alert as it attempts to load the detail cards based on the new resource uri.  