### PR TITLE
fix: Default Field filters should always apply on initialization, not just initially

### DIFF
--- a/assets/src/mixins/InteractsWithFieldFilters.js
+++ b/assets/src/mixins/InteractsWithFieldFilters.js
@@ -9,7 +9,7 @@ const InteractsWithFieldFilters = {
       this.clearAllFieldFilters();
       if (this.encodedFieldFilters) {
         this.currentFieldFilters = JSON.parse(atob(this.encodedFieldFilters));
-      } else if (this.resourceInformation && this.resourceInformation.default_filters && this.initialLoading){
+      } else if (this.resourceInformation && this.resourceInformation.default_filters){
         this.currentFieldFilters = this.resourceInformation.default_filters;
         this.updateQueryString({
           [this.pageParameter]: 1,


### PR DESCRIPTION
Fix a bug where default field filters where applied inconsistently,
leading to inconsistent UI that only sometimes applied default field
filters.

This was caused by attempting to only set these values on initial load,
which in the land of Vue & Vue Router is not always every load.
