### PR TITLE
fix: except on forms should only touch forms

### DIFF
--- a/lib/ex_teal/field_visibility.ex
+++ b/lib/ex_teal/field_visibility.ex
@@ -14,9 +14,7 @@ defmodule ExTeal.FieldVisibility do
   def except_on_forms(field),
     do: %{
       field
-      | show_on_detail: true,
-        show_on_edit: false,
-        show_on_index: true,
+      | show_on_edit: false,
         show_on_new: false
     }
 


### PR DESCRIPTION
Make `except_on_forms()` only set show on new/edit to false (not also index/detail).