### PR TITLE
fix: Serializer should consider errors where the key is an array

### DIFF
--- a/lib/ex_teal/api/error_serializer.ex
+++ b/lib/ex_teal/api/error_serializer.ex
@@ -12,16 +12,14 @@ defmodule ExTeal.Api.ErrorSerializer do
   See `Ecto.Changeset.traverse_errors/2`
   """
   def translate_errors(%Changeset{} = changeset) do
-    Changeset.traverse_errors(changeset, &parse_changeset_error/1)
-  end
-
-  defp parse_changeset_error({msg, opts}) do
-    Enum.reduce(opts, msg, fn {key, value}, acc ->
-      String.replace(acc, "%{#{key}}", to_string(value))
+    Changeset.traverse_errors(changeset, fn {message, opts} ->
+      Regex.replace(~r"%{(\w+)}", message, fn _, key ->
+        opts
+        |> Keyword.get(String.to_existing_atom(key), key)
+        |> to_string()
+      end)
     end)
   end
-
-  defp parse_changeset_error(msg), do: msg
 
   def render(%Changeset{} = changeset) do
     # When encoded, the changeset returns its errors

--- a/test/ex_teal/api/error_serializer_test.exs
+++ b/test/ex_teal/api/error_serializer_test.exs
@@ -1,10 +1,24 @@
 defmodule ExTeal.Api.ErrorSerializerTest do
   use ExUnit.Case, async: true
+  alias Ecto.Changeset
 
   alias ExTeal.Api.ErrorSerializer
 
   test "flatten/1 returns a flattened map" do
     assert ErrorSerializer.flatten(%{foo: %{bar: "baz"}}) == %{"foo.bar" => "baz"}
     assert ErrorSerializer.flatten(%{foo: %{bar: ["baz"]}}) == %{"foo.bar" => ["baz"]}
+  end
+
+  test "translate_errors/1" do
+    data = %{}
+    types = %{name: :string}
+    params = %{name: nil}
+
+    changeset =
+      {data, types}
+      |> Changeset.cast(params, Map.keys(types))
+      |> Changeset.validate_required(Map.keys(types))
+
+    assert ErrorSerializer.translate_errors(changeset) == %{name: ["can't be blank"]}
   end
 end


### PR DESCRIPTION
[Ecto.Changset.unsafe_validate_change/4](https://hexdocs.pm/ecto/3.10.3/Ecto.Changeset.html#unsafe_validate_unique/3) can return a changeset whose errors includes a key that is an array.  This was breaking teal's error serialization.