### PR TITLE
fix: BelongsTo Form disabled when it should be editable on new forms

### DIFF
--- a/assets/src/components/Form/BelongsTo.vue
+++ b/assets/src/components/Form/BelongsTo.vue
@@ -5,7 +5,7 @@
   >
     <template slot="field">
       <search-input
-        :disabled="isLocked"
+        :disabled="creatingViaRelatedResource"
         :error="hasError"
         :value="selectedResource"
         :data="availableResources"
@@ -153,10 +153,6 @@ export default {
         }
       };
     },
-
-    isLocked () {
-      return this.viaResource == this.field.options.belongs_to_relationship;
-    }
   },
 
   /**


### PR DESCRIPTION
Related to #239.

When on a 'Create' form, the BelongsTo field should be locked only when it's the
reverse of the referencing relationship.
