### PR TITLE
feat: Enable Trend Metrics to use date fields

### DIFF
--- a/lib/ex_teal/metric/ranges.ex
+++ b/lib/ex_teal/metric/ranges.ex
@@ -121,4 +121,8 @@ defmodule ExTeal.Metric.Ranges do
   defp to_dt_field_type(value, :utc_datetime) do
     value
   end
+
+  defp to_dt_field_type(value, :date) do
+    DateTime.to_date(value)
+  end
 end

--- a/lib/ex_teal/metric/trend.ex
+++ b/lib/ex_teal/metric/trend.ex
@@ -151,44 +151,22 @@ defmodule ExTeal.Metric.Trend do
         unit,
         timezone
       ) do
+    format = result_format(unit)
+
     date =
-      case unit do
-        "year" ->
-          date
-          |> to_local_dt("{YYYY}", timezone)
-          |> to_result_date()
-
-        "month" ->
-          date
-          |> to_local_dt("{YYYY}-{0M}", timezone)
-          |> to_result_date()
-
-        "week" ->
-          date
-          |> to_local_dt("{YYYY}-{Wiso}", timezone)
-          |> to_result_date()
-
-        "day" ->
-          date
-          |> to_local_dt("{YYYY}-{0M}-{0D}", timezone)
-          |> to_result_date()
-
-        "hour" ->
-          date
-          |> to_local_dt("{YYYY}-{0M}-{0D} {h24}:{m}", timezone)
-          |> to_result_date()
-
-        "minute" ->
-          date
-          |> to_local_dt("{YYYY}-{0M}-{0D} {h24}:{m}", timezone)
-          |> to_result_date()
-
-        true ->
-          nil
-      end
+      date
+      |> to_local_dt(format, timezone)
+      |> to_result_date()
 
     {date, val}
   end
+
+  defp result_format("year"), do: "{YYYY}"
+  defp result_format("month"), do: "{YYYY}-{0M}"
+  defp result_format("week"), do: "{YYYY}-{Wiso}"
+  defp result_format("day"), do: "{YYYY}-{0M}-{0D}"
+  defp result_format("hour"), do: "{YYYY}-{0M}-{0D} {h24}:{m}"
+  defp result_format(_), do: "{YYYY}-{0M}-{0D} {h24}:{m}"
 
   def get_possible_results(start_dt, end_dt, request, timezone) do
     tz = Timezone.get(timezone, start_dt)

--- a/test/ex_teal/resource/export_test.exs
+++ b/test/ex_teal/resource/export_test.exs
@@ -94,7 +94,7 @@ defmodule ExTeal.Resource.ExportTest do
       [header, p1_csv, p2_csv] = String.split(data, "\r\n", trim: true)
 
       assert header ==
-               "id,name,body,author,contributor,published,published_at,deleted_at,features,location,user_id,editor_id,inserted_at,updated_at"
+               "id,name,body,author,contributor,published,published_at,featured_on,deleted_at,features,location,user_id,editor_id,inserted_at,updated_at"
 
       assert String.contains?(p1_csv, "#{p1.id},#{p1.name}")
       assert String.contains?(p2_csv, "#{p2.id},#{p2.name}")
@@ -156,7 +156,7 @@ defmodule ExTeal.Resource.ExportTest do
       [header, p1_csv, p2_csv] = String.split(data, "\r\n", trim: true)
 
       assert header ==
-               "id,name,body,author,contributor,published,published_at,deleted_at,features,location,user_id,editor_id,inserted_at,updated_at"
+               "id,name,body,author,contributor,published,published_at,featured_on,deleted_at,features,location,user_id,editor_id,inserted_at,updated_at"
 
       assert String.contains?(p1_csv, "#{p2.id},#{p2.name}")
       assert String.contains?(p2_csv, "#{p1.id},#{p1.name}")
@@ -194,7 +194,7 @@ defmodule ExTeal.Resource.ExportTest do
       fields = TestExTeal.PostResource.export_fields()
 
       expected =
-        ~w(id name body author contributor published published_at deleted_at features location user_id editor_id inserted_at updated_at)a
+        ~w(id name body author contributor published published_at featured_on deleted_at features location user_id editor_id inserted_at updated_at)a
 
       assert fields == expected
     end

--- a/test/support/dashboards.exs
+++ b/test/support/dashboards.exs
@@ -1,5 +1,6 @@
 defmodule TestExTeal.MainDashboard do
   use ExTeal.Dashboard
 
-  def cards(_conn), do: [TestExTeal.NewUsersMetric, TestExTeal.RevenueTrend]
+  def cards(_conn),
+    do: [TestExTeal.NewUsersMetric, TestExTeal.RevenueTrend, TestExTeal.PostFeaturedTrend]
 end

--- a/test/support/metrics.exs
+++ b/test/support/metrics.exs
@@ -19,6 +19,20 @@ defmodule TestExTeal.NewUserTrend do
   end
 end
 
+defmodule TestExTeal.PostFeaturedTrend do
+  use ExTeal.Metric.Trend
+  @impl true
+  def calculate(request) do
+    count(request, TestExTeal.Post)
+  end
+
+  @impl true
+  def date_field, do: :featured_on
+
+  @impl true
+  def date_field_type, do: :date
+end
+
 defmodule TestExTeal.RevenueTrend do
   use ExTeal.Metric.Trend
 

--- a/test/support/migrations.exs
+++ b/test/support/migrations.exs
@@ -25,6 +25,7 @@ defmodule TestExTeal.Migrations do
       add(:editor_id, references(:users))
       add(:published, :boolean, default: false, null: false)
       add(:published_at, :naive_datetime)
+      add(:featured_on, :date)
       add(:deleted_at, :utc_datetime)
 
       timestamps()

--- a/test/support/schema.exs
+++ b/test/support/schema.exs
@@ -70,6 +70,7 @@ defmodule TestExTeal.Post do
     field(:contributor, :string)
     field(:published, :boolean)
     field(:published_at, :naive_datetime)
+    field(:featured_on, :date)
     field(:deleted_at, :utc_datetime)
 
     embeds_one(:features, Features, on_replace: :update)
@@ -86,7 +87,7 @@ defmodule TestExTeal.Post do
     timestamps()
   end
 
-  @fields ~w(name body author contributor published published_at deleted_at user_id editor_id)a
+  @fields ~w(name body author contributor published published_at featured_on deleted_at user_id editor_id)a
 
   def changeset(%Post{} = post, params \\ %{}) do
     post


### PR DESCRIPTION
Teal indirectly allowed users to configure metrics based on date fields but delivered inaccurate results as it relied on timezone offset and interval math that was not relevant to aggregating over date fields.  This PR adds proper `date` support to Trend metrics 