### PR TITLE
fix: sorting an index request should pass the conn to the child fields

### DIFF
--- a/lib/ex_teal/resource/index.ex
+++ b/lib/ex_teal/resource/index.ex
@@ -180,7 +180,7 @@ defmodule ExTeal.Resource.Index do
       resource
       |> Fields.index_fields(conn)
       |> Enum.find(&(&1.attribute == field))
-      |> then(& &1.type.apply_options_for(&1, new_schema, %{}, :index))
+      |> then(& &1.type.apply_options_for(&1, new_schema, conn, :index))
 
     handle_sort(query, field_struct, String.to_existing_atom(field), dir)
   end


### PR DESCRIPTION
This pull request includes a small but important change to the `ExTeal.Resource.Index` module. The change ensures that the `conn` parameter is passed to the `apply_options_for` function, which is essential for handling connection-specific options.

* [`lib/ex_teal/resource/index.ex`](diffhunk://#diff-c3b1370c5c0a607a193f6b9233a98c0e1bab6e6f49708ce61fda9f48a5f31791L183-R183): Modified the `apply_options_for` function call to include the `conn` parameter, ensuring proper handling of connection-specific options.